### PR TITLE
Fix YapDatabase API change from string based filePath to NSURL

### DIFF
--- a/src/Messages/Attachements/TSAttachmentStream.m
+++ b/src/Messages/Attachements/TSAttachmentStream.m
@@ -29,7 +29,7 @@ NSString *const TSAttachementFileRelationshipEdge = @"TSAttachementFileEdge";
 - (NSArray *)yapDatabaseRelationshipEdges {
     YapDatabaseRelationshipEdge *attachmentFileEdge =
         [YapDatabaseRelationshipEdge edgeWithName:TSAttachementFileRelationshipEdge
-                              destinationFilePath:[self filePath]
+                               destinationFileURL:[self mediaURL]
                                   nodeDeleteRules:YDB_DeleteDestinationIfSourceDeleted];
 
     return @[ attachmentFileEdge ];


### PR DESCRIPTION
YapDatabase 2.8 changed the use of strings to NSURL for referencing files.

https://github.com/yapstudios/YapDatabase/wiki/Changelog

`API Change: YapDatabaseRelationship now uses NSURL to reference destination files. It previously used a string-based filePath, which proved especially brittle on iOS/Simulator, as the app's home folder is regularly moved by the operating system (which would break all non-relative filePath's, which is what the relationship extension wanted to store). The new system enforces NSURL, and takes advantage of NSURL's bookmark system to ensure that file references remain valid even if the filePath changes.`
