### PR TITLE
Fix compiler warning

### DIFF
--- a/src/Protocols/ContactsManagerProtocol.h
+++ b/src/Protocols/ContactsManagerProtocol.h
@@ -14,7 +14,6 @@
 
 - (NSString *)nameStringForPhoneIdentifier:(NSString *)phoneNumber;
 + (BOOL)name:(NSString *)nameString matchesQuery:(NSString *)queryString;
-+ (BOOL)phoneNumber:(PhoneNumber *)phoneNumber matchesQuery:(NSString *)queryString;
 
 #if TARGET_OS_IPHONE
 - (UIImage *)imageForPhoneIdentifier:(NSString *)phoneNumber;

--- a/src/Protocols/UserPreferences.h
+++ b/src/Protocols/UserPreferences.h
@@ -1,5 +1,5 @@
 //
-//  ContactsManagerProtocol.h
+//  UserPreferences.h
 //  Pods
 //
 //  Created by Frederic Jacobs on 05/12/15.


### PR DESCRIPTION
Removed the unused implementation earlier, but neglected to remove the signature from this protocol, resulting in a compiler warning.
