### PR TITLE
Avoid deadlock while accepting new key

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,14 +1,10 @@
 ---
-BasedOnStyle: Chromium
-AlignTrailingComments: true
-AlignConsecutiveAssignments: true
-AllowShortIfStatementsOnASingleLine: false
-BreakBeforeBraces: Attach
+BasedOnStyle: WebKit
+AllowShortFunctionsOnASingleLine: false
 BinPackArguments: false
 BinPackParameters: false
 ColumnLimit: 120
-IndentWidth: 4
-KeepEmptyLinesAtTheStartOfBlocks: false
+IndentCaseLabels: true
 MaxEmptyLinesToKeep: 2
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true

--- a/src/Contacts/TSThread.m
+++ b/src/Contacts/TSThread.m
@@ -21,7 +21,7 @@
 @property (nonatomic, retain) NSDate *lastMessageDate;
 @property (nonatomic, copy) NSString *messageDraft;
 
-- (TSInteraction *) lastInteraction;
+- (TSInteraction *)lastInteraction;
 
 @end
 
@@ -111,7 +111,7 @@
     if (self.lastInteraction == nil) {
         return @"";
     } else {
-        return self.lastInteraction.description;
+        return [self lastInteraction].description;
     }
 }
 

--- a/src/Messages/Interactions/TSMessage.m
+++ b/src/Messages/Interactions/TSMessage.m
@@ -55,13 +55,25 @@ NSString *const TSAttachementsRelationshipEdgeName = @"TSAttachmentEdge";
     return self;
 }
 
-- (BOOL)hasAttachments {
+- (BOOL)hasAttachments
+{
     return self.attachments ? (self.attachments.count > 0) : false;
 }
 
-- (NSString *)description {
+- (NSString *)debugDescription
+{
     if ([self hasAttachments]) {
-        NSString *attachmentId   = self.attachments[0];
+        NSString *attachmentId = self.attachments[0];
+        return [NSString stringWithFormat:@"Media Message with attachmentId:%@", attachmentId];
+    } else {
+        return [NSString stringWithFormat:@"Message with body:%@", self.body];
+    }
+}
+
+- (NSString *)description
+{
+    if ([self hasAttachments]) {
+        NSString *attachmentId = self.attachments[0];
         TSAttachment *attachment = [TSAttachment fetchObjectWithUniqueID:attachmentId];
         if (attachment) {
             return attachment.description;

--- a/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyReceivingErrorMessage.m
+++ b/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyReceivingErrorMessage.m
@@ -69,7 +69,7 @@
                                   NSString *collection, NSString *key, id object, NSUInteger index, BOOL *stop) {
                                 TSInteraction *interaction = (TSInteraction *)object;
 
-                                DDLogVerbose(@"Interaction type: %@", interaction.description);
+                                DDLogVerbose(@"Interaction type: %@", interaction.debugDescription);
 
                                 if ([interaction isKindOfClass:[TSInvalidIdentityKeyErrorMessage class]]) {
                                     TSInvalidIdentityKeyErrorMessage *invalidKeyMessage =


### PR DESCRIPTION
Using description in log output crashes when the description is a media
message, since printing media description uses a transaction within our
existing transaction.

Instead we'll use a simpler debugDescription for simple text building,
like logging.

// FREEBIE
