### PR TITLE
Accepting keychange only resends to single recipient

### DIFF
--- a/src/Messages/TSMessagesManager+sendMessages.h
+++ b/src/Messages/TSMessagesManager+sendMessages.h
@@ -18,4 +18,10 @@ typedef void (^failedSendingCompletionBlock)();
             success:(successSendingCompletionBlock)successCompletionBlock
             failure:(failedSendingCompletionBlock)failedCompletionBlock;
 
+- (void)resendMessage:(TSOutgoingMessage *)message
+          toRecipient:(SignalRecipient *)recipient
+             inThread:(TSThread *)thread
+              success:(successSendingCompletionBlock)successCompletionBlock
+              failure:(failedSendingCompletionBlock)failedCompletionBlock;
+
 @end


### PR DESCRIPTION
Only resend to the single failed recipient when accepting a new key.

Will solve https://github.com/WhisperSystems/Signal-iOS/issues/951 so we don't resend to everyone in the group.

// FREEBIE
