### PR TITLE
Handle animated content type in TSAttachment:descritpion:

### DIFF
--- a/src/Messages/Attachments/TSAttachment.m
+++ b/src/Messages/Attachments/TSAttachment.m
@@ -44,6 +44,8 @@
         return [NSString stringWithFormat:@"📽 %@", attachmentString];
     } else if ([MIMETypeUtil isAudio:self.contentType]) {
         return [NSString stringWithFormat:@"📻 %@", attachmentString];
+    } else if ([MIMETypeUtil isAnimated:self.contentType]) {
+        return [NSString stringWithFormat:@"🎡 %@", attachmentString];
     }
 
     return attachmentString;


### PR DESCRIPTION
Displaying icons for gifs was missing in messages list cells
(https://github.com/WhisperSystems/Signal-iOS/issues/1271).

//FREEBE
