### PR TITLE
Fix: deleting thread sometimes fails to recover disk space, new thread reappears with old messages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - cd $TEST_DIR
   - brew update
   - brew outdated xctool || brew upgrade xctool
-  - gem install cocoapods --no-ri --no-rdoc
+  - gem install cocoapods xcpretty --no-ri --no-rdoc
   - pod repo update --silent
 
 install: pod install
@@ -16,7 +16,11 @@ install: pod install
 script:
 - |
   set -o pipefail
-  xcodebuild -workspace TSKitiOSTestApp.xcworkspace -scheme TSKitiOSTestApp -sdk iphonesimulator build test
+  xcodebuild -workspace TSKitiOSTestApp.xcworkspace \
+             -scheme TSKitiOSTestApp \
+             -sdk iphonesimulator \
+             -destination 'platform=iOS Simulator,name=iPhone 6' \
+             build test | xcpretty
 
 xcode_workspace: TSKitiOSTestApp.xcworkspace
 xcode_scheme: TSKitiOSTestApp

--- a/Example/TSKitiOSTestApp/Podfile.lock
+++ b/Example/TSKitiOSTestApp/Podfile.lock
@@ -34,7 +34,7 @@ PODS:
   - Mantle/extobjc (2.0.7)
   - ProtocolBuffers (1.9.10)
   - Reachability (3.2)
-  - SignalServiceKit (0.0.6):
+  - SignalServiceKit (0.0.7):
     - '25519'
     - AFNetworking
     - AxolotlKit
@@ -129,7 +129,7 @@ SPEC CHECKSUMS:
   Mantle: bc40bb061d8c2c6fb48d5083e04d928c3b7f73d9
   ProtocolBuffers: d088180c10072b3d24a9939a6314b7b9bcc2340b
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  SignalServiceKit: 850620cd1535f8628474121e7ea142ff1fe236a6
+  SignalServiceKit: e0bc81d12cef07b621403ff49e1c9c6f64d96109
   SocketRocket: 3f77ec2104cc113add553f817ad90a77114f5d43
   SQLCipher: 4c768761421736a247ed6cf412d9045615d53dff
   SSKeychain: c71293fa57216a40ab06c23f4085387583293de4

--- a/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		308D7DFA789594CEA62740D9 /* libPods-TSKitiOSTestAppTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C0DC1A83C39CBC09FB2405A3 /* libPods-TSKitiOSTestAppTests.a */; };
+		452EE6CF1D4A754C00E934BA /* TSThreadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 452EE6CE1D4A754C00E934BA /* TSThreadTest.m */; };
+		452EE6D51D4AC43300E934BA /* OWSOrphanedDataCleanerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 452EE6D41D4AC43300E934BA /* OWSOrphanedDataCleanerTest.m */; };
 		45458B751CC342B600A02153 /* SignedPreKeyDeletionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 45458B6A1CC342B600A02153 /* SignedPreKeyDeletionTests.m */; };
 		45458B761CC342B600A02153 /* TSAttachmentsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 45458B6C1CC342B600A02153 /* TSAttachmentsTest.m */; };
 		45458B771CC342B600A02153 /* TSMessageStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 45458B6E1CC342B600A02153 /* TSMessageStorageTests.m */; };
@@ -42,6 +44,8 @@
 		1A50A62A8930EE2BC9B8AC11 /* Pods-TSKitiOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TSKitiOSTestApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-TSKitiOSTestApp/Pods-TSKitiOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
 		31DFDA8F9523F5B15EA2376B /* Pods-TSKitiOSTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TSKitiOSTestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TSKitiOSTestApp/Pods-TSKitiOSTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		36DA6C703F99948D553F4E3F /* Pods-TSKitiOSTestAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TSKitiOSTestAppTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TSKitiOSTestAppTests/Pods-TSKitiOSTestAppTests.debug.xcconfig"; sourceTree = "<group>"; };
+		452EE6CE1D4A754C00E934BA /* TSThreadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSThreadTest.m; sourceTree = "<group>"; };
+		452EE6D41D4AC43300E934BA /* OWSOrphanedDataCleanerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OWSOrphanedDataCleanerTest.m; sourceTree = "<group>"; };
 		45458B6A1CC342B600A02153 /* SignedPreKeyDeletionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SignedPreKeyDeletionTests.m; sourceTree = "<group>"; };
 		45458B6C1CC342B600A02153 /* TSAttachmentsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSAttachmentsTest.m; sourceTree = "<group>"; };
 		45458B6E1CC342B600A02153 /* TSMessageStorageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSMessageStorageTests.m; sourceTree = "<group>"; };
@@ -51,6 +55,7 @@
 		45458B731CC342B600A02153 /* CryptographyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CryptographyTests.m; sourceTree = "<group>"; };
 		45458B741CC342B600A02153 /* MessagePaddingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MessagePaddingTests.m; sourceTree = "<group>"; };
 		459850C01D22C6F2006FFEDB /* PhoneNumberTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PhoneNumberTest.m; path = ../../../tests/Contacts/PhoneNumberTest.m; sourceTree = "<group>"; };
+		459FE0DA1D4AD49E00E1071A /* TSKitiOSTestApp-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TSKitiOSTestApp-Prefix.pch"; sourceTree = "<group>"; };
 		45A856AB1D220BFF0056CD4D /* TSAttributesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSAttributesTest.m; sourceTree = "<group>"; };
 		45C6A0991D2F029B007D8AC0 /* TSMessageTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TSMessageTest.m; path = ../../../tests/Messages/Interactions/TSMessageTest.m; sourceTree = "<group>"; };
 		B6273DD11C13A2E500738558 /* TSKitiOSTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TSKitiOSTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -116,6 +121,7 @@
 				45458B6F1CC342B600A02153 /* TSStorageIdentityKeyStoreTests.m */,
 				45458B701CC342B600A02153 /* TSStoragePreKeyStoreTests.m */,
 				45458B711CC342B600A02153 /* TSStorageSignedPreKeyStore.m */,
+				452EE6D41D4AC43300E934BA /* OWSOrphanedDataCleanerTest.m */,
 			);
 			name = Storage;
 			path = ../../../tests/Storage;
@@ -135,6 +141,7 @@
 			isa = PBXGroup;
 			children = (
 				459850C01D22C6F2006FFEDB /* PhoneNumberTest.m */,
+				452EE6CE1D4A754C00E934BA /* TSThreadTest.m */,
 			);
 			name = Contacts;
 			sourceTree = "<group>";
@@ -207,6 +214,7 @@
 				B6273DE21C13A2E500738558 /* LaunchScreen.storyboard */,
 				B6273DE51C13A2E500738558 /* Info.plist */,
 				B6273DD41C13A2E500738558 /* Supporting Files */,
+				459FE0DA1D4AD49E00E1071A /* TSKitiOSTestApp-Prefix.pch */,
 			);
 			path = TSKitiOSTestApp;
 			sourceTree = "<group>";
@@ -446,6 +454,8 @@
 				45458B751CC342B600A02153 /* SignedPreKeyDeletionTests.m in Sources */,
 				45458B7B1CC342B600A02153 /* CryptographyTests.m in Sources */,
 				45458B791CC342B600A02153 /* TSStoragePreKeyStoreTests.m in Sources */,
+				452EE6D51D4AC43300E934BA /* OWSOrphanedDataCleanerTest.m in Sources */,
+				452EE6CF1D4A754C00E934BA /* TSThreadTest.m in Sources */,
 				45458B761CC342B600A02153 /* TSAttachmentsTest.m in Sources */,
 				45C6A09A1D2F029B007D8AC0 /* TSMessageTest.m in Sources */,
 				459850C11D22C6F2006FFEDB /* PhoneNumberTest.m in Sources */,
@@ -597,6 +607,8 @@
 			baseConfigurationReference = 36DA6C703F99948D553F4E3F /* Pods-TSKitiOSTestAppTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(SRCROOT)/$(PROJECT_NAME)/TSKitiOSTestApp-Prefix.pch";
 				INFOPLIST_FILE = TSKitiOSTestAppTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.whispersystems.TSKitiOSTestAppTests;
@@ -610,6 +622,8 @@
 			baseConfigurationReference = D3737F7A041D7147015C02C2 /* Pods-TSKitiOSTestAppTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(SRCROOT)/$(PROJECT_NAME)/TSKitiOSTestApp-Prefix.pch";
 				INFOPLIST_FILE = TSKitiOSTestAppTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.whispersystems.TSKitiOSTestAppTests;

--- a/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/xcshareddata/xcschemes/TSKitiOSTestApp.xcscheme
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/xcshareddata/xcschemes/TSKitiOSTestApp.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:TSKitiOSTestApp.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1D0826C97B09E58C83B3C228FBC535FA"
+               BuildableName = "libSignalServiceKit.a"
+               BlueprintName = "SignalServiceKit"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Example/TSKitiOSTestApp/TSKitiOSTestApp/TSKitiOSTestApp-Prefix.pch
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestApp/TSKitiOSTestApp-Prefix.pch
@@ -1,0 +1,8 @@
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#ifndef TSKitiOSTestApp_Prefix_pch
+#define TSKitiOSTestApp_Prefix_pch
+
+#import <Foundation/Foundation.h>
+
+#endif /* TSKitiOSTestApp_Prefix_pch */

--- a/Example/TSKitiOSTestApp/TSKitiOSTestAppTests/TSThreadTest.m
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestAppTests/TSThreadTest.m
@@ -1,0 +1,91 @@
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "TSAttachmentStream.h"
+#import "TSContactThread.h"
+#import "TSIncomingMessage.h"
+#import "TSOutgoingMessage.h"
+#import "TSStorageManager.h"
+#import <XCTest/XCTest.h>
+
+@interface TSThreadTest : XCTestCase
+
+@end
+
+@implementation TSThreadTest
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Register views, etc.
+    [[TSStorageManager sharedManager] setupDatabase];
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testDeletingThreadDeletesInteractions
+{
+    TSContactThread *thread = [[TSContactThread alloc] initWithUniqueId:@"fake-test-thread"];
+    [thread save];
+
+    [TSInteraction removeAllObjectsInCollection];
+    XCTAssertEqual(0, [thread numberOfInteractions]);
+
+    TSIncomingMessage *incomingMessage = [[TSIncomingMessage alloc] initWithTimestamp:10000
+                                                                             inThread:thread
+                                                                          messageBody:@"incoming message body"
+                                                                          attachments:nil];
+    [incomingMessage save];
+
+    TSOutgoingMessage *outgoingMessage = [[TSOutgoingMessage alloc] initWithTimestamp:20000
+                                                                             inThread:thread
+                                                                          messageBody:@"outgoing message body"
+                                                                          attachments:nil];
+    [outgoingMessage save];
+
+    XCTAssertEqual(2, [thread numberOfInteractions]);
+
+    [thread remove];
+    XCTAssertEqual(0, [thread numberOfInteractions]);
+    XCTAssertEqual(0, [TSInteraction numberOfKeysInCollection]);
+}
+
+- (void)testDeletingThreadDeletesAttachmentFiles
+{
+    TSContactThread *thread = [[TSContactThread alloc] initWithUniqueId:@"fake-test-thread"];
+    [thread save];
+
+    // Sanity check
+    [TSInteraction removeAllObjectsInCollection];
+    XCTAssertEqual(0, [thread numberOfInteractions]);
+
+    TSAttachmentStream *attachment = [[TSAttachmentStream alloc] initWithIdentifier:@"fake-photo-attachment-id"
+                                                                               data:[[NSData alloc] init]
+                                                                                key:[[NSData alloc] init]
+                                                                        contentType:@"image/jpeg"];
+    [attachment save];
+
+    BOOL fileWasCreated = [[NSFileManager defaultManager] fileExistsAtPath:[attachment filePath]];
+    XCTAssert(fileWasCreated);
+
+    TSIncomingMessage *incomingMessage = [[TSIncomingMessage alloc] initWithTimestamp:10000
+                                                                             inThread:thread
+                                                                          messageBody:@"incoming message body"
+                                                                          attachments:@[ attachment.uniqueId ]];
+    [incomingMessage save];
+
+    // Sanity check
+    XCTAssertEqual(1, [thread numberOfInteractions]);
+
+    [thread remove];
+    XCTAssertEqual(0, [thread numberOfInteractions]);
+
+    BOOL fileStillExists = [[NSFileManager defaultManager] fileExistsAtPath:[attachment filePath]];
+    XCTAssertFalse(fileStillExists);
+}
+
+@end

--- a/Example/TSKitiOSTestApp/TSKitiOSTestAppTests/TSThreadTest.m
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestAppTests/TSThreadTest.m
@@ -38,13 +38,13 @@
     TSIncomingMessage *incomingMessage = [[TSIncomingMessage alloc] initWithTimestamp:10000
                                                                              inThread:thread
                                                                           messageBody:@"incoming message body"
-                                                                          attachments:nil];
+                                                                        attachmentIds:nil];
     [incomingMessage save];
 
     TSOutgoingMessage *outgoingMessage = [[TSOutgoingMessage alloc] initWithTimestamp:20000
                                                                              inThread:thread
                                                                           messageBody:@"outgoing message body"
-                                                                          attachments:nil];
+                                                                        attachmentIds:nil];
     [outgoingMessage save];
 
     XCTAssertEqual(2, [thread numberOfInteractions]);
@@ -75,7 +75,7 @@
     TSIncomingMessage *incomingMessage = [[TSIncomingMessage alloc] initWithTimestamp:10000
                                                                              inThread:thread
                                                                           messageBody:@"incoming message body"
-                                                                          attachments:@[ attachment.uniqueId ]];
+                                                                        attachmentIds:@[ attachment.uniqueId ]];
     [incomingMessage save];
 
     // Sanity check

--- a/SignalServiceKit.podspec
+++ b/SignalServiceKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SignalServiceKit"
-  s.version          = "0.0.6"
+  s.version          = "0.0.7"
   s.summary          = "An Objective-C library for communicating with the Signal messaging service."
 
   s.description      = <<-DESC

--- a/src/Contacts/TSThread.h
+++ b/src/Contacts/TSThread.h
@@ -1,15 +1,8 @@
-//
-//  TSThread.h
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 16/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
-
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 #import "TSYapDatabaseObject.h"
+#import <UIKit/UIKit.h>
 
 @class TSInteraction;
 
@@ -42,7 +35,12 @@
 - (UIImage *)image;
 #endif
 
-#pragma mark Read Status
+#pragma mark Interactions
+
+/**
+ *  @return The number of interactions in this thread.
+ */
+- (NSUInteger)numberOfInteractions;
 
 /**
  *  Returns whether or not the thread has unread messages.
@@ -52,8 +50,6 @@
 - (BOOL)hasUnreadMessages;
 
 - (void)markAllAsReadWithTransaction:(YapDatabaseReadWriteTransaction *)transaction;
-
-#pragma mark Last Interactions
 
 /**
  *  Returns the latest date of a message in the thread or the thread creation date if there are no messages in that

--- a/src/Contacts/TSThread.m
+++ b/src/Contacts/TSThread.m
@@ -6,13 +6,12 @@
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
 //
 
-#import "TSDatabaseView.h"
-#import "TSInteraction.h"
-#import "TSStorageManager.h"
 #import "TSThread.h"
-
+#import "TSDatabaseView.h"
 #import "TSIncomingMessage.h"
+#import "TSInteraction.h"
 #import "TSOutgoingMessage.h"
+#import "TSStorageManager.h"
 
 @interface TSThread ()
 

--- a/src/Contacts/TSThread.m
+++ b/src/Contacts/TSThread.m
@@ -1,10 +1,5 @@
-//
-//  TSThread.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 16/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
 #import "TSThread.h"
 #import "TSDatabaseView.h"
@@ -43,6 +38,33 @@
     return self;
 }
 
+- (void)remove
+{
+    [[self dbConnection] readWriteWithBlock:^(YapDatabaseReadWriteTransaction *_Nonnull transaction) {
+        [self removeWithTransaction:transaction];
+    }];
+}
+
+- (void)removeWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
+{
+    [super removeWithTransaction:transaction];
+
+    __block NSMutableArray<NSString *> *interactionIds = [[NSMutableArray alloc] init];
+    [self enumerateInteractionsWithTransaction:transaction
+                                    usingBlock:^(TSInteraction *interaction, YapDatabaseReadTransaction *transaction) {
+                                        [interactionIds addObject:interaction.uniqueId];
+                                    }];
+
+    for (NSString *interactionId in interactionIds) {
+        // This might seem redundant since we're fetching the interaction twice, once above to get the uniqueIds
+        // and then again here. The issue is we can't remove them within the enumeration (you can't mutate an
+        // enumeration source), but we also want to avoid instantiating an entire threads worth of Interaction objects
+        // at once. This way we only have a threads worth of interactionId's.
+        TSInteraction *interaction = [TSInteraction fetchObjectWithUniqueID:interactionId transaction:transaction];
+        [interaction removeWithTransaction:transaction];
+    }
+}
+
 #pragma mark To be subclassed.
 
 - (BOOL)isGroupThread {
@@ -59,7 +81,39 @@
     return nil;
 }
 
-#pragma mark Read Status
+#pragma mark Interactions
+
+/**
+ * Iterate over this thread's interactions
+ */
+- (void)enumerateInteractionsWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
+                                  usingBlock:(void (^)(TSInteraction *interaction,
+                                                 YapDatabaseReadTransaction *transaction))block
+{
+    void (^interactionBlock)(NSString *, NSString *, id, id, NSUInteger, BOOL *) = ^void(NSString *_Nonnull collection,
+        NSString *_Nonnull key,
+        id _Nonnull object,
+        id _Nonnull metadata,
+        NSUInteger index,
+        BOOL *_Nonnull stop) {
+
+        TSInteraction *interaction = object;
+        block(interaction, transaction);
+    };
+
+    YapDatabaseViewTransaction *interactionsByThread = [transaction ext:TSMessageDatabaseViewExtensionName];
+    [interactionsByThread enumerateRowsInGroup:self.uniqueId usingBlock:interactionBlock];
+}
+
+- (NSUInteger)numberOfInteractions
+{
+    __block NSUInteger count;
+    [[self dbConnection] readWithBlock:^(YapDatabaseReadTransaction *_Nonnull transaction) {
+        YapDatabaseViewTransaction *interactionsByThread = [transaction ext:TSMessageDatabaseViewExtensionName];
+        count = [interactionsByThread numberOfItemsInGroup:self.uniqueId];
+    }];
+    return count;
+}
 
 - (BOOL)hasUnreadMessages {
     TSInteraction *interaction = self.lastInteraction;
@@ -87,8 +141,6 @@
         [message saveWithTransaction:transaction];
     }
 }
-
-#pragma mark Last Interactions
 
 - (TSInteraction *) lastInteraction {
     __block TSInteraction *last;

--- a/src/Contacts/Threads/TSContactThread.m
+++ b/src/Contacts/Threads/TSContactThread.m
@@ -1,15 +1,11 @@
-//
-//  TSContactThread.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 16/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
+#import "TSContactThread.h"
 #import "ContactsUpdater.h"
 #import "IncomingPushMessageSignal.pb.h"
-#import "TSContactThread.h"
 #import "TextSecureKitEnv.h"
+#import <YapDatabase/YapDatabaseTransaction.h>
 
 #define TSContactThreadPrefix @"c"
 

--- a/src/Contacts/Threads/TSGroupThread.m
+++ b/src/Contacts/Threads/TSGroupThread.m
@@ -1,14 +1,10 @@
-//
-//  TSGroupThread.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 16/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
+#import "TSGroupThread.h"
 #import "NSData+Base64.h"
 #import "SignalRecipient.h"
-#import "TSGroupThread.h"
+#import <YapDatabase/YapDatabaseTransaction.h>
 
 @implementation TSGroupThread
 

--- a/src/Messages/Attachments/TSAttachment.m
+++ b/src/Messages/Attachments/TSAttachment.m
@@ -1,14 +1,8 @@
-
-//
-//  TSAttachement.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 12/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
-#import "MIMETypeUtil.h"
 #import "TSAttachment.h"
+#import "MIMETypeUtil.h"
 
 @implementation TSAttachment
 

--- a/src/Messages/Attachments/TSAttachmentPointer.h
+++ b/src/Messages/Attachments/TSAttachmentPointer.h
@@ -1,15 +1,11 @@
-//
-//  TSAttachementPointer.h
-//  Signal
-//
 //  Created by Frederic Jacobs on 17/12/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
-
-#import <Foundation/Foundation.h>
 
 #import "TSAttachment.h"
 
+/**
+ * A TSAttachmentPointer is a yet-to-be-downloaded attachment.
+ */
 @interface TSAttachmentPointer : TSAttachment
 
 - (instancetype)initWithIdentifier:(uint64_t)identifier

--- a/src/Messages/Attachments/TSAttachmentPointer.m
+++ b/src/Messages/Attachments/TSAttachmentPointer.m
@@ -1,10 +1,5 @@
-//
-//  TSAttachementPointer.m
-//  Signal
-//
 //  Created by Frederic Jacobs on 17/12/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
 #import "TSAttachmentPointer.h"
 

--- a/src/Messages/Attachments/TSAttachmentStream.h
+++ b/src/Messages/Attachments/TSAttachmentStream.h
@@ -6,7 +6,7 @@
 #import <UIKit/UIKit.h>
 #endif
 
-@interface TSAttachmentStream : TSAttachment <YapDatabaseRelationshipNode>
+@interface TSAttachmentStream : TSAttachment
 
 @property (nonatomic) BOOL isDownloaded;
 
@@ -22,9 +22,11 @@
 - (BOOL)isAnimated;
 - (BOOL)isImage;
 - (BOOL)isVideo;
+- (NSString *)filePath;
 - (NSURL *)mediaURL;
 
 + (void)deleteAttachments;
 + (NSString *)attachmentsFolder;
++ (NSUInteger)numberOfItemsInAttachmentsFolder;
 
 @end

--- a/src/Messages/Attachments/TSAttachmentStream.h
+++ b/src/Messages/Attachments/TSAttachmentStream.h
@@ -1,10 +1,5 @@
-//
-//  TSAttachementStream.h
-//  Signal
-//
 //  Created by Frederic Jacobs on 17/12/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
 #import "TSAttachment.h"
 #if TARGET_OS_IPHONE
@@ -19,7 +14,6 @@
                               data:(NSData *)data
                                key:(NSData *)key
                        contentType:(NSString *)contentType NS_DESIGNATED_INITIALIZER;
-;
 
 #if TARGET_OS_IPHONE
 - (UIImage *)image;

--- a/src/Messages/Interactions/TSErrorMessage.m
+++ b/src/Messages/Interactions/TSErrorMessage.m
@@ -16,12 +16,15 @@
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
                          inThread:(TSThread *)thread
-                failedMessageType:(TSErrorMessageType)errorMessageType {
-    self = [super initWithTimestamp:timestamp inThread:thread messageBody:nil attachments:nil];
+                failedMessageType:(TSErrorMessageType)errorMessageType
+{
+    self = [super initWithTimestamp:timestamp inThread:thread messageBody:nil attachmentIds:nil];
 
-    if (self) {
-        _errorType = errorMessageType;
+    if (!self) {
+        return self;
     }
+
+    _errorType = errorMessageType;
 
     [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForErrorMessage:self inThread:thread];
 

--- a/src/Messages/Interactions/TSErrorMessage.m
+++ b/src/Messages/Interactions/TSErrorMessage.m
@@ -7,6 +7,7 @@
 //
 
 #import "TSErrorMessage.h"
+#import "TSContactThread.h"
 #import "TSErrorMessage_privateConstructor.h"
 #import "TSMessagesManager.h"
 #import "TextSecureKitEnv.h"

--- a/src/Messages/Interactions/TSIncomingMessage.h
+++ b/src/Messages/Interactions/TSIncomingMessage.h
@@ -16,10 +16,14 @@
 /**
  *  Initiates an incoming message
  *
- *  @param timestamp    timestamp of the message in milliseconds since epoch
- *  @param thread       thread to which the message belongs
- *  @param body         body of the message
- *  @param attachments attachments of the message
+ *  @param timestamp
+ *    Timestamp of the message in milliseconds since epoch
+ *  @param thread
+ *    Thread to which the message belongs
+ *  @param body
+ *    Body of the message
+ *  @param attachmentIds
+ *    The uniqueIds for the message's attachments
  *
  *  @return initiated incoming message
  */
@@ -27,16 +31,21 @@
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
                          inThread:(TSContactThread *)thread
                       messageBody:(NSString *)body
-                      attachments:(NSArray *)attachments;
+                    attachmentIds:(NSArray<NSString *> *)attachmentIds;
 
 /**
  *  Initiates an incoming group message
  *
- *  @param timestamp    timestamp of the message in milliseconds since epoch
- *  @param thread       thread to which the message belongs
- *  @param authorId     author identifier of the user in the group that sent the message
- *  @param body         body of the message
- *  @param attachments attachments of the message
+ *  @param timestamp
+ *    Timestamp of the message in milliseconds since epoch
+ *  @param thread
+ *    Thread to which the message belongs
+ *  @param authorId
+ *    Author identifier of the user in the group that sent the message
+ *  @param body
+ *    Body of the message
+ *  @param attachmentIds
+ *    The uniqueIds for the message's attachments
  *
  *  @return initiated incoming group message
  */
@@ -45,7 +54,7 @@
                          inThread:(TSGroupThread *)thread
                          authorId:(NSString *)authorId
                       messageBody:(NSString *)body
-                      attachments:(NSArray *)attachments;
+                    attachmentIds:(NSArray<NSString *> *)attachmentIds;
 
 @property (nonatomic, readonly) NSString *authorId;
 @property (nonatomic, getter=wasRead) BOOL read;

--- a/src/Messages/Interactions/TSIncomingMessage.h
+++ b/src/Messages/Interactions/TSIncomingMessage.h
@@ -8,6 +8,9 @@
 
 #import "TSMessage.h"
 
+@class TSContactThread;
+@class TSGroupThread;
+
 @interface TSIncomingMessage : TSMessage
 
 /**

--- a/src/Messages/Interactions/TSIncomingMessage.m
+++ b/src/Messages/Interactions/TSIncomingMessage.m
@@ -7,6 +7,8 @@
 //
 
 #import "TSIncomingMessage.h"
+#import "TSContactThread.h"
+#import "TSGroupThread.h"
 
 @implementation TSIncomingMessage
 

--- a/src/Messages/Interactions/TSIncomingMessage.m
+++ b/src/Messages/Interactions/TSIncomingMessage.m
@@ -16,14 +16,17 @@
                          inThread:(TSGroupThread *)thread
                          authorId:(NSString *)authorId
                       messageBody:(NSString *)body
-                      attachments:(NSArray *)attachments {
-    self = [super initWithTimestamp:timestamp inThread:thread messageBody:body attachments:attachments];
+                    attachmentIds:(NSArray<NSString *> *)attachmentIds
+{
+    self = [super initWithTimestamp:timestamp inThread:thread messageBody:body attachmentIds:attachmentIds];
 
-    if (self) {
-        _authorId   = authorId;
-        _read       = NO;
-        _receivedAt = [NSDate date];
+    if (!self) {
+        return self;
     }
+
+    _authorId = authorId;
+    _read = NO;
+    _receivedAt = [NSDate date];
 
     return self;
 }
@@ -31,14 +34,17 @@
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
                          inThread:(TSContactThread *)thread
                       messageBody:(NSString *)body
-                      attachments:(NSArray *)attachments {
-    self = [super initWithTimestamp:timestamp inThread:thread messageBody:body attachments:attachments];
+                    attachmentIds:(NSArray<NSString *> *)attachmentIds
+{
+    self = [super initWithTimestamp:timestamp inThread:thread messageBody:body attachmentIds:attachmentIds];
 
-    if (self) {
-        _authorId   = nil;
-        _read       = NO;
-        _receivedAt = [NSDate date];
+    if (!self) {
+        return self;
     }
+
+    _authorId = nil;
+    _read = NO;
+    _receivedAt = [NSDate date];
 
     return self;
 }

--- a/src/Messages/Interactions/TSInfoMessage.m
+++ b/src/Messages/Interactions/TSInfoMessage.m
@@ -13,12 +13,15 @@
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
                          inThread:(TSThread *)thread
-                      messageType:(TSInfoMessageType)infoMessage {
-    self = [super initWithTimestamp:timestamp inThread:thread messageBody:nil attachments:nil];
+                      messageType:(TSInfoMessageType)infoMessage
+{
+    self = [super initWithTimestamp:timestamp inThread:thread messageBody:nil attachmentIds:nil];
 
-    if (self) {
-        _messageType = infoMessage;
+    if (!self) {
+        return self;
     }
+
+    _messageType = infoMessage;
 
     return self;
 }

--- a/src/Messages/Interactions/TSInteraction.h
+++ b/src/Messages/Interactions/TSInteraction.h
@@ -5,11 +5,7 @@
 
 @class TSThread;
 
-extern const struct TSMessageRelationships { __unsafe_unretained NSString *threadUniqueId; } TSMessageRelationships;
-
-extern const struct TSMessageEdges { __unsafe_unretained NSString *thread; } TSMessageEdges;
-
-@interface TSInteraction : TSYapDatabaseObject <YapDatabaseRelationshipNode>
+@interface TSInteraction : TSYapDatabaseObject
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp inThread:(TSThread *)thread;
 

--- a/src/Messages/Interactions/TSInteraction.h
+++ b/src/Messages/Interactions/TSInteraction.h
@@ -1,18 +1,9 @@
-//
-//  TSInteraction.h
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 12/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
-
-#import <Foundation/Foundation.h>
-#import <YapDatabase/YapDatabaseRelationshipNode.h>
 
 #import "TSYapDatabaseObject.h"
 
-#import "TSContactThread.h"
-#import "TSGroupThread.h"
+@class TSThread;
 
 extern const struct TSMessageRelationships { __unsafe_unretained NSString *threadUniqueId; } TSMessageRelationships;
 

--- a/src/Messages/Interactions/TSInteraction.m
+++ b/src/Messages/Interactions/TSInteraction.m
@@ -7,9 +7,9 @@
 //
 
 #import "TSInteraction.h"
-
 #import "TSDatabaseSecondaryIndexes.h"
 #import "TSStorageManager+messageIDs.h"
+#import "TSThread.h"
 
 
 const struct TSMessageRelationships TSMessageRelationships = {

--- a/src/Messages/Interactions/TSInteraction.m
+++ b/src/Messages/Interactions/TSInteraction.m
@@ -1,24 +1,10 @@
-//
-//  TSInteraction.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 12/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
 #import "TSInteraction.h"
 #import "TSDatabaseSecondaryIndexes.h"
 #import "TSStorageManager+messageIDs.h"
 #import "TSThread.h"
-
-
-const struct TSMessageRelationships TSMessageRelationships = {
-    .threadUniqueId = @"threadUniqueId",
-};
-
-const struct TSMessageEdges TSMessageEdges = {
-    .thread = @"thread",
-};
 
 @implementation TSInteraction
 
@@ -54,23 +40,6 @@ const struct TSMessageEdges TSMessageEdges = {
                       usingTransaction:transaction];
 
     return interaction;
-}
-
-
-#pragma mark YapDatabaseRelationshipNode
-
-- (NSArray *)yapDatabaseRelationshipEdges {
-    NSArray *edges = nil;
-    if (self.uniqueThreadId) {
-        YapDatabaseRelationshipEdge *threadEdge =
-            [YapDatabaseRelationshipEdge edgeWithName:TSMessageEdges.thread
-                                       destinationKey:self.uniqueThreadId
-                                           collection:[TSThread collection]
-                                      nodeDeleteRules:YDB_DeleteSourceIfDestinationDeleted];
-        edges = @[ threadEdge ];
-    }
-
-    return edges;
 }
 
 + (NSString *)collection {

--- a/src/Messages/Interactions/TSMessage.h
+++ b/src/Messages/Interactions/TSMessage.h
@@ -1,17 +1,10 @@
-//
-//  TSMessage.h
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 12/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
-#import <Foundation/Foundation.h>
-#import "TSAttachment.h"
 #import "TSInteraction.h"
 
 /**
- *  Abstract message class. Is instantiated by either
+ *  Abstract message class.
  */
 
 typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {

--- a/src/Messages/Interactions/TSMessage.h
+++ b/src/Messages/Interactions/TSMessage.h
@@ -16,17 +16,15 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 };
 @interface TSMessage : TSInteraction
 
-@property (nonatomic, readonly) NSMutableArray<NSString *> *attachments;
+@property (nonatomic, readonly) NSMutableArray<NSString *> *attachmentIds;
 @property (nonatomic) NSString *body;
 @property (nonatomic) TSGroupMetaMessage groupMetaMessage;
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
                          inThread:(TSThread *)thread
                       messageBody:(NSString *)body
-                      attachments:(NSArray<NSString *> *)attachments;
+                    attachmentIds:(NSArray<NSString *> *)attachmentIds;
 
-- (void)addattachments:(NSArray<NSString *> *)attachments;
-- (void)addattachment:(NSString *)attachment;
 - (BOOL)hasAttachments;
 
 @end

--- a/src/Messages/Interactions/TSMessage.m
+++ b/src/Messages/Interactions/TSMessage.m
@@ -1,12 +1,9 @@
-//
-//  TSMessage.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 12/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
 #import "TSMessage.h"
+#import "TSAttachment.h"
+#import <YapDatabase/YapDatabaseTransaction.h>
 
 NSString *const TSAttachementsRelationshipEdgeName = @"TSAttachmentEdge";
 

--- a/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/src/Messages/Interactions/TSOutgoingMessage.m
@@ -1,12 +1,8 @@
-//
-//  TSOutgoingMessage.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 15/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
 #import "TSOutgoingMessage.h"
+#import "TSGroupThread.h"
 
 @implementation TSOutgoingMessage
 

--- a/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/src/Messages/Interactions/TSOutgoingMessage.m
@@ -9,16 +9,19 @@
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
                          inThread:(TSThread *)thread
                       messageBody:(NSString *)body
-                      attachments:(NSMutableArray *)attachments {
-    self = [super initWithTimestamp:timestamp inThread:thread messageBody:body attachments:attachments];
+                    attachmentIds:(NSMutableArray<NSString *> *)attachmentIds
+{
+    self = [super initWithTimestamp:timestamp inThread:thread messageBody:body attachmentIds:attachmentIds];
 
-    if (self) {
-        _messageState = TSOutgoingMessageStateAttemptingOut;
-        if ([thread isKindOfClass:[TSGroupThread class]]) {
-            self.groupMetaMessage = TSGroupMessageDeliver;
-        } else {
-            self.groupMetaMessage = TSGroupMessageNone;
-        }
+    if (!self) {
+        return self;
+    }
+
+    _messageState = TSOutgoingMessageStateAttemptingOut;
+    if ([thread isKindOfClass:[TSGroupThread class]]) {
+        self.groupMetaMessage = TSGroupMessageDeliver;
+    } else {
+        self.groupMetaMessage = TSGroupMessageNone;
     }
 
     return self;

--- a/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyReceivingErrorMessage.m
+++ b/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyReceivingErrorMessage.m
@@ -1,23 +1,18 @@
-//
-//  TSInvalidIdentityKeyErrorMessage.m
-//  Signal
-//
 //  Created by Frederic Jacobs on 31/12/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
-#import <YapDatabase/YapDatabaseTransaction.h>
-#import <YapDatabase/YapDatabaseView.h>
-
-#import <AxolotlKit/NSData+keyVersionByte.h>
-#import <AxolotlKit/PreKeyWhisperMessage.h>
+#import "TSInvalidIdentityKeyReceivingErrorMessage.h"
+#import "TSContactThread.h"
 #import "TSDatabaseView.h"
 #import "TSErrorMessage_privateConstructor.h"
 #import "TSFingerprintGenerator.h"
-#import "TSInvalidIdentityKeyReceivingErrorMessage.h"
 #import "TSMessagesManager.h"
 #import "TSStorageManager+IdentityKeyStore.h"
 #import "TSStorageManager.h"
+#import <AxolotlKit/NSData+keyVersionByte.h>
+#import <AxolotlKit/PreKeyWhisperMessage.h>
+#import <YapDatabase/YapDatabaseTransaction.h>
+#import <YapDatabase/YapDatabaseView.h>
 
 @implementation TSInvalidIdentityKeyReceivingErrorMessage
 

--- a/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.m
+++ b/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.m
@@ -11,6 +11,7 @@
 #import <AxolotlKit/NSData+keyVersionByte.h>
 
 #import "PreKeyBundle+jsonDict.h"
+#import "TSContactThread.h"
 #import "TSErrorMessage_privateConstructor.h"
 #import "TSFingerprintGenerator.h"
 #import "TSInvalidIdentityKeySendingErrorMessage.h"

--- a/src/Messages/TSCall.h
+++ b/src/Messages/TSCall.h
@@ -1,13 +1,9 @@
-//
-//  TSCall.h
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 12/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
-#import <Foundation/Foundation.h>
 #import "TSInteraction.h"
+
+@class TSContactThread;
 
 typedef enum {
     RPRecentCallTypeIncoming = 1,

--- a/src/Messages/TSCall.m
+++ b/src/Messages/TSCall.m
@@ -1,12 +1,8 @@
-//
-//  TSCall.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 12/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
 #import "TSCall.h"
+#import "TSContactThread.h"
 
 @implementation TSCall
 

--- a/src/Messages/TSGroupModel.h
+++ b/src/Messages/TSGroupModel.h
@@ -1,13 +1,11 @@
 //  Created by Frederic Jacobs.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
 
-#import <Foundation/Foundation.h>
 #import "TSYapDatabaseObject.h"
 
 @interface TSGroupModel : TSYapDatabaseObject
 
 @property (nonatomic, strong) NSMutableArray *groupMemberIds;
-@property (nonatomic, strong) NSString *associatedAttachmentId;
 @property (nonatomic, strong) NSString *groupName;
 @property (nonatomic, strong) NSData *groupId;
 
@@ -17,8 +15,7 @@
 - (instancetype)initWithTitle:(NSString *)title
                     memberIds:(NSMutableArray *)memberIds
                         image:(UIImage *)image
-                      groupId:(NSData *)groupId
-       associatedAttachmentId:(NSString *)attachmentId;
+                      groupId:(NSData *)groupId;
 
 - (BOOL)isEqual:(id)other;
 - (BOOL)isEqualToGroupModel:(TSGroupModel *)model;

--- a/src/Messages/TSGroupModel.m
+++ b/src/Messages/TSGroupModel.m
@@ -3,8 +3,6 @@
 
 #import "TSGroupModel.h"
 
-NSString *const TSAttachementGroupAvatarFileRelationshipEdge = @"TSAttachementGroupAvatarFileEdge";
-
 @implementation TSGroupModel
 
 #if TARGET_OS_IOS
@@ -12,11 +10,10 @@ NSString *const TSAttachementGroupAvatarFileRelationshipEdge = @"TSAttachementGr
                     memberIds:(NSMutableArray *)memberIds
                         image:(UIImage *)image
                       groupId:(NSData *)groupId
-       associatedAttachmentId:(NSString *)attachmentId {
+{
     _groupName              = title;
     _groupMemberIds         = [memberIds copy];
-    _groupImage             = image;
-    _associatedAttachmentId = attachmentId;
+    _groupImage = image; // image is stored in DB
     _groupId                = groupId;
 
     return self;

--- a/src/Messages/TSMessagesManager+attachments.m
+++ b/src/Messages/TSMessagesManager+attachments.m
@@ -1,19 +1,18 @@
-//
-//  TSMessagesManager+attachments.m
-//  Signal
-//
 //  Created by Frederic Jacobs on 17/12/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
-#import <YapDatabase/YapDatabaseConnection.h>
 #import "Cryptography.h"
 #import "MIMETypeUtil.h"
 #import "NSDate+millisecondTimeStamp.h"
 #import "TSAttachmentPointer.h"
+#import "TSContactThread.h"
+#import "TSGroupModel.h"
+#import "TSGroupThread.h"
 #import "TSInfoMessage.h"
 #import "TSMessagesManager+attachments.h"
 #import "TSNetworkManager.h"
+#import <YapDatabase/YapDatabaseConnection.h>
+#import <YapDatabase/YapDatabaseTransaction.h>
 
 @interface TSMessagesManager ()
 
@@ -195,6 +194,9 @@ dispatch_queue_t attachmentsQueue() {
                     [self decryptedAndSaveAttachment:attachment data:data messageId:messageId];
                 }
               });
+          } else {
+              DDLogError(@"Failed retrieval of attachment. Response had unexpected format.");
+              [self setFailedAttachment:attachment inMessage:messageId];
           }
         }
         failure:^(NSURLSessionDataTask *task, NSError *error) {

--- a/src/Messages/TSMessagesManager+sendMessages.h
+++ b/src/Messages/TSMessagesManager+sendMessages.h
@@ -8,6 +8,8 @@
 
 #import "TSMessagesManager.h"
 
+@class SignalRecipient;
+
 @interface TSMessagesManager (sendMessages)
 
 typedef void (^successSendingCompletionBlock)();

--- a/src/Messages/TSMessagesManager+sendMessages.m
+++ b/src/Messages/TSMessagesManager+sendMessages.m
@@ -524,8 +524,8 @@ dispatch_queue_t sendingQueue() {
                 break;
             case TSGroupMessageUpdate:
             case TSGroupMessageNew: {
-                if (gThread.groupModel.groupImage != nil && [message.attachments count] == 1) {
-                    id dbObject = [TSAttachmentStream fetchObjectWithUniqueID:[message.attachments firstObject]];
+                if (gThread.groupModel.groupImage != nil && [message.attachmentIds count] == 1) {
+                    id dbObject = [TSAttachmentStream fetchObjectWithUniqueID:message.attachmentIds[0]];
                     if ([dbObject isKindOfClass:[TSAttachmentStream class]]) {
                         TSAttachmentStream *attachment = (TSAttachmentStream *)dbObject;
                         PushMessageContentAttachmentPointerBuilder *attachmentbuilder =
@@ -550,8 +550,8 @@ dispatch_queue_t sendingQueue() {
         [builder setGroup:groupBuilder.build];
     }
     if (processAttachments) {
-        NSMutableArray *attachmentsArray = [NSMutableArray array];
-        for (NSString *attachmentId in message.attachments) {
+        NSMutableArray *attachments = [NSMutableArray new];
+        for (NSString *attachmentId in message.attachmentIds) {
             id dbObject = [TSAttachmentStream fetchObjectWithUniqueID:attachmentId];
 
             if ([dbObject isKindOfClass:[TSAttachmentStream class]]) {
@@ -563,10 +563,10 @@ dispatch_queue_t sendingQueue() {
                 [attachmentbuilder setContentType:attachment.contentType];
                 [attachmentbuilder setKey:attachment.encryptionKey];
 
-                [attachmentsArray addObject:[attachmentbuilder build]];
+                [attachments addObject:[attachmentbuilder build]];
             }
         }
-        [builder setAttachmentsArray:attachmentsArray];
+        [builder setAttachmentsArray:attachments];
     }
     return [builder.build data];
 }

--- a/src/Messages/TSMessagesManager+sendMessages.m
+++ b/src/Messages/TSMessagesManager+sendMessages.m
@@ -1,7 +1,6 @@
 //  Created by Frederic Jacobs on 17/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
 
-#import "TSMessagesManager+sendMessages.h"
 #import "ContactsUpdater.h"
 #import "NSData+messagePadding.h"
 #import "PreKeyBundle+jsonDict.h"
@@ -10,6 +9,7 @@
 #import "TSContactThread.h"
 #import "TSGroupThread.h"
 #import "TSInfoMessage.h"
+#import "TSMessagesManager+sendMessages.h"
 #import "TSNetworkManager.h"
 #import "TSServerMessage.h"
 #import "TSStorageHeaders.h"

--- a/src/Messages/TSMessagesManager+sendMessages.m
+++ b/src/Messages/TSMessagesManager+sendMessages.m
@@ -1,27 +1,23 @@
-//
-//  TSMessagesManager+sendMessages.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 17/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
 #import "TSMessagesManager+sendMessages.h"
-
-#import <AxolotlKit/AxolotlExceptions.h>
-#import <AxolotlKit/SessionBuilder.h>
-#import <AxolotlKit/SessionCipher.h>
-#import <Mantle/Mantle.h>
-#import <TwistedOakCollapsingFutures/CollapsingFutures.h>
 #import "ContactsUpdater.h"
 #import "NSData+messagePadding.h"
 #import "PreKeyBundle+jsonDict.h"
 #import "TSAccountManager.h"
 #import "TSAttachmentStream.h"
+#import "TSContactThread.h"
+#import "TSGroupThread.h"
 #import "TSInfoMessage.h"
 #import "TSNetworkManager.h"
 #import "TSServerMessage.h"
 #import "TSStorageHeaders.h"
+#import <AxolotlKit/AxolotlExceptions.h>
+#import <AxolotlKit/SessionBuilder.h>
+#import <AxolotlKit/SessionCipher.h>
+#import <Mantle/Mantle.h>
+#import <TwistedOakCollapsingFutures/CollapsingFutures.h>
 
 #define RETRY_ATTEMPTS 3
 
@@ -92,7 +88,6 @@ dispatch_queue_t sendingQueue() {
 {
     if ([thread isKindOfClass:[TSGroupThread class]]) {
         dispatch_async(sendingQueue(), ^{
-            TSGroupThread *groupThread = (TSGroupThread *)thread;
             [self groupSend:@[ recipient ] // Avoid spamming entire group when resending failed message.
                     Message:message
                    inThread:thread

--- a/src/Messages/TSMessagesManager.h
+++ b/src/Messages/TSMessagesManager.h
@@ -22,10 +22,10 @@
                 inThread:(TSThread *)thread;
 - (void)handleReceivedMessage:(IncomingPushMessageSignal *)message
                   withContent:(PushMessageContent *)content
-                  attachments:(NSArray *)attachments;
+                attachmentIds:(NSArray<NSString *> *)attachmentIds;
 - (void)handleReceivedMessage:(IncomingPushMessageSignal *)message
                   withContent:(PushMessageContent *)content
-                  attachments:(NSArray *)attachments
+                attachmentIds:(NSArray<NSString *> *)attachmentIds
               completionBlock:(void (^)(NSString *messageIdentifier))completionBlock;
 
 - (void)handleSendToMyself:(TSOutgoingMessage *)outgoingMessage;

--- a/src/Messages/TSMessagesManager.h
+++ b/src/Messages/TSMessagesManager.h
@@ -1,17 +1,13 @@
-//
-//  TSMessagesHandler.h
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 11/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
-#import <Foundation/Foundation.h>
 #import "IncomingPushMessageSignal.pb.h"
 #import "TSIncomingMessage.h"
 #import "TSInvalidIdentityKeySendingErrorMessage.h"
 #import "TSOutgoingMessage.h"
+
 @class TSCall;
+@class YapDatabaseConnection;
 
 @interface TSMessagesManager : NSObject
 

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -2,8 +2,6 @@
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
 
 #import "TSMessagesManager.h"
-#import <AxolotlKit/AxolotlExceptions.h>
-#import <AxolotlKit/SessionCipher.h>
 #import "NSData+messagePadding.h"
 #import "TSAccountManager.h"
 #import "TSAttachmentStream.h"
@@ -17,6 +15,8 @@
 #import "TSMessagesManager+attachments.h"
 #import "TSStorageHeaders.h"
 #import "TextSecureKitEnv.h"
+#import <AxolotlKit/AxolotlExceptions.h>
+#import <AxolotlKit/SessionCipher.h>
 
 @interface TSMessagesManager ()
 

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -1,27 +1,22 @@
-//
-//  TSMessagesHandler.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 11/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
 #import "TSMessagesManager.h"
-
 #import <AxolotlKit/AxolotlExceptions.h>
 #import <AxolotlKit/SessionCipher.h>
-
 #import "NSData+messagePadding.h"
 #import "TSAccountManager.h"
 #import "TSAttachmentStream.h"
 #import "TSCall.h"
+#import "TSContactThread.h"
 #import "TSDatabaseView.h"
+#import "TSGroupModel.h"
+#import "TSGroupThread.h"
 #import "TSInfoMessage.h"
 #import "TSInvalidIdentityKeyReceivingErrorMessage.h"
 #import "TSMessagesManager+attachments.h"
 #import "TSStorageHeaders.h"
 #import "TextSecureKitEnv.h"
-
 
 @interface TSMessagesManager ()
 

--- a/src/Storage/OWSOrphanedDataCleaner.h
+++ b/src/Storage/OWSOrphanedDataCleaner.h
@@ -1,0 +1,10 @@
+// Copyright (c) 2016 Open Whisper Systems. All rights reserved.
+
+@interface OWSOrphanedDataCleaner : NSObject
+
+/**
+ * Remove any inaccessible data left behind due to application bugs.
+ */
+- (void)removeOrphanedData;
+
+@end

--- a/src/Storage/OWSOrphanedDataCleaner.m
+++ b/src/Storage/OWSOrphanedDataCleaner.m
@@ -1,0 +1,91 @@
+// Copyright (c) 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSOrphanedDataCleaner.h"
+#import "TSAttachmentStream.h"
+#import "TSInteraction.h"
+#import "TSMessage.h"
+#import "TSStorageManager.h"
+#import "TSThread.h"
+
+@implementation OWSOrphanedDataCleaner
+
+- (void)removeOrphanedData
+{
+    // Remove interactions whose threads have been deleted
+    for (NSString *interactionId in [self orphanedInteractionIds]) {
+        DDLogWarn(@"Removing orphaned interaction with id: %@", interactionId);
+        TSInteraction *interaction = [TSInteraction fetchObjectWithUniqueID:interactionId];
+        [interaction remove];
+    }
+
+    // Remove any lingering attachments
+    for (NSString *path in [self orphanedFilePaths]) {
+        DDLogWarn(@"Removing orphaned file attachment at path: %@", path);
+        NSError *error;
+        [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
+        if (error) {
+            DDLogError(@"Unable to remove orphaned file attachment at path:%@", path);
+        }
+    }
+}
+
+- (NSArray<NSString *> *)orphanedInteractionIds
+{
+    NSMutableArray *interactionIds = [NSMutableArray new];
+    [[TSInteraction dbConnection] readWithBlock:^(YapDatabaseReadTransaction *_Nonnull transaction) {
+        [TSInteraction enumerateCollectionObjectsWithTransaction:transaction
+                                                      usingBlock:^(TSInteraction *interaction, BOOL *stop) {
+                                                          TSThread *thread = [TSThread
+                                                              fetchObjectWithUniqueID:interaction.uniqueThreadId
+                                                                          transaction:transaction];
+                                                          if (!thread) {
+                                                              [interactionIds addObject:interaction.uniqueId];
+                                                          }
+                                                      }];
+    }];
+
+
+    return [interactionIds copy];
+}
+
+- (NSArray<NSString *> *)orphanedFilePaths
+{
+    NSError *error;
+    NSMutableArray<NSString *> *filenames =
+        [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:[TSAttachmentStream attachmentsFolder] error:&error]
+            mutableCopy];
+    if (error) {
+        DDLogError(@"error getting orphanedFilePaths:%@", error);
+        return @[];
+    }
+
+    NSMutableDictionary<NSString *, NSString *> *attachmentIdFilenames = [NSMutableDictionary new];
+    for (NSString *filename in filenames) {
+        // Remove extension from (e.g.) 1234.png to get the attachmentId "1234"
+        NSString *attachmentId = [filename stringByDeletingPathExtension];
+        attachmentIdFilenames[attachmentId] = filename;
+    }
+
+    [TSInteraction enumerateCollectionObjectsUsingBlock:^(TSInteraction *interaction, BOOL *stop) {
+        if ([interaction isKindOfClass:[TSMessage class]]) {
+            TSMessage *message = (TSMessage *)interaction;
+            if ([message hasAttachments]) {
+                for (NSString *attachmentId in message.attachmentIds) {
+                    [attachmentIdFilenames removeObjectForKey:attachmentId];
+                }
+            }
+        }
+    }];
+
+    // TODO Make sure we're not deleting group update avatars
+    NSArray<NSString *> *filenamesToDelete = [attachmentIdFilenames allValues];
+    NSMutableArray<NSString *> *absolutePathsToDelete = [NSMutableArray arrayWithCapacity:[filenamesToDelete count]];
+    for (NSString *filename in filenamesToDelete) {
+        NSString *absolutePath = [[TSAttachmentStream attachmentsFolder] stringByAppendingFormat:@"/%@", filename];
+        [absolutePathsToDelete addObject:absolutePath];
+    }
+
+    return [absolutePathsToDelete copy];
+}
+
+@end

--- a/src/Storage/TSStorageManager.m
+++ b/src/Storage/TSStorageManager.m
@@ -60,8 +60,6 @@ static NSString *keychainDBPassAccount    = @"TSDatabasePass";
     [TSDatabaseView registerUnreadDatabaseView];
 
     [self.database registerExtension:[TSDatabaseSecondaryIndexes registerTimeStampIndex] withName:@"idx"];
-
-    [self.database registerExtension:[[YapDatabaseRelationship alloc] init] withName:@"TSRelationships"];
 }
 
 

--- a/src/Storage/TSStorageManager.m
+++ b/src/Storage/TSStorageManager.m
@@ -1,22 +1,17 @@
-//
-//  TSStorageManager.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 27/10/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
-
-#import <25519/Randomness.h>
-#import <SSKeychain/SSKeychain.h>
-#import <YapDatabase/YapDatabaseRelationship.h>
+#import "TSStorageManager.h"
 #import "NSData+Base64.h"
+#import "SignalRecipient.h"
 #import "TSAttachmentStream.h"
 #import "TSDatabaseSecondaryIndexes.h"
 #import "TSDatabaseView.h"
 #import "TSInteraction.h"
-#import "TSStorageManager.h"
 #import "TSThread.h"
+#import <25519/Randomness.h>
+#import <SSKeychain/SSKeychain.h>
+#import <YapDatabase/YapDatabaseRelationship.h>
 
 NSString *const TSUIDatabaseConnectionDidUpdateNotification = @"TSUIDatabaseConnectionDidUpdateNotification";
 

--- a/src/Storage/TSYapDatabaseObject.h
+++ b/src/Storage/TSYapDatabaseObject.h
@@ -1,16 +1,10 @@
-//
-//  TSYapDatabaseObject.h
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 16/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
-
-#import <Foundation/Foundation.h>
 
 #import <Mantle/MTLModel+NSCoding.h>
-#import "YapDatabaseRelationshipNode.h"
-#import "YapDatabaseTransaction.h"
+
+@class YapDatabaseReadTransaction;
+@class YapDatabaseReadWriteTransaction;
 
 @interface TSYapDatabaseObject : MTLModel
 
@@ -29,8 +23,8 @@
  *
  *  @return Key (string) identifying the collection
  */
-
 + (NSString *)collection;
+
 
 /**
  *  Fetches the object with the provided identifier
@@ -38,7 +32,7 @@
  *  @param uniqueID    Unique identifier of the entry in a collection
  *  @param transaction Transaction used for fetching the object
  *
- *  @return Returns and instance of the object or nil if non-existent
+ *  @return Instance of the object or nil if non-existent
  */
 
 + (instancetype)fetchObjectWithUniqueID:(NSString *)uniqueID transaction:(YapDatabaseReadTransaction *)transaction;

--- a/src/Storage/TSYapDatabaseObject.h
+++ b/src/Storage/TSYapDatabaseObject.h
@@ -3,6 +3,7 @@
 
 #import <Mantle/MTLModel+NSCoding.h>
 
+@class YapDatabaseConnection;
 @class YapDatabaseReadTransaction;
 @class YapDatabaseReadWriteTransaction;
 
@@ -15,8 +16,7 @@
  *
  *  @return Initialized object
  */
-
-- (instancetype)initWithUniqueId:(NSString *)uniqueId;
+- (instancetype)initWithUniqueId:(NSString *)uniqueId NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Returns the collection to which the object belongs.
@@ -25,6 +25,41 @@
  */
 + (NSString *)collection;
 
+/**
+ * Get the number of keys in the models collection. Be aware that if there
+ * are multiple object types in this collection that the count will include
+ * the count of other objects in the same collection.
+ *
+ * @return The number of keys in the classes collection.
+ */
++ (NSUInteger)numberOfKeysInCollection;
+
+/**
+ * Removes all objects in the classes collection.
+ */
++ (void)removeAllObjectsInCollection;
+
+/**
+ * A memory intesive method to get all objects in the collection. You should prefer using enumeration over this method
+ * whenever feasible. See `enumerateObjectsInCollectionUsingBlock`
+ *
+ * @return All objects in the classes collection.
+ */
++ (NSArray *)allObjectsInCollection;
+
+/**
+ * Enumerates all objects in collection.
+ */
++ (void)enumerateCollectionObjectsUsingBlock:(void (^)(id obj, BOOL *stop))block;
++ (void)enumerateCollectionObjectsWithTransaction:(YapDatabaseReadTransaction *)transaction
+                                       usingBlock:(void (^)(id object, BOOL *stop))block;
+
+
+/**
+ * @return A shared database connection.
+ */
+- (YapDatabaseConnection *)dbConnection;
++ (YapDatabaseConnection *)dbConnection;
 
 /**
  *  Fetches the object with the provided identifier

--- a/src/Storage/TSYapDatabaseObject.m
+++ b/src/Storage/TSYapDatabaseObject.m
@@ -1,13 +1,9 @@
-//
-//  TSYapDatabaseObject.m
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 16/11/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
-#import "TSStorageManager.h"
 #import "TSYapDatabaseObject.h"
+#import "TSStorageManager.h"
+#import <YapDatabase/YapDatabaseTransaction.h>
 
 @implementation TSYapDatabaseObject
 
@@ -40,7 +36,6 @@
     [transaction removeObjectForKey:self.uniqueId inCollection:[[self class] collection]];
 }
 
-
 - (void)remove {
     [[TSStorageManager sharedManager]
             .dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
@@ -48,7 +43,6 @@
       [[transaction ext:@"relationships"] flush];
     }];
 }
-
 
 #pragma mark Class Methods
 

--- a/src/Storage/TSYapDatabaseObject.m
+++ b/src/Storage/TSYapDatabaseObject.m
@@ -7,61 +7,119 @@
 
 @implementation TSYapDatabaseObject
 
-- (id)init {
-    if (self = [super init]) {
-        _uniqueId = [[NSUUID UUID] UUIDString];
+- (instancetype)init
+{
+    return [self initWithUniqueId:[[NSUUID UUID] UUIDString]];
+}
+
+- (instancetype)initWithUniqueId:(NSString *)aUniqueId
+{
+    self = [super init];
+    if (!self) {
+        return self;
     }
+
+    _uniqueId = aUniqueId;
+
     return self;
 }
 
-- (instancetype)initWithUniqueId:(NSString *)aUniqueId {
-    if (self = [super init]) {
-        _uniqueId = aUniqueId;
-    }
-    return self;
-}
-
-- (void)saveWithTransaction:(YapDatabaseReadWriteTransaction *)transaction {
+- (void)saveWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
+{
     [transaction setObject:self forKey:self.uniqueId inCollection:[[self class] collection]];
 }
 
-- (void)save {
-    [[TSStorageManager sharedManager]
-            .dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-      [self saveWithTransaction:transaction];
+- (void)save
+{
+    [[self dbConnection] readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        [self saveWithTransaction:transaction];
     }];
 }
 
-- (void)removeWithTransaction:(YapDatabaseReadWriteTransaction *)transaction {
+- (void)removeWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
+{
     [transaction removeObjectForKey:self.uniqueId inCollection:[[self class] collection]];
 }
 
-- (void)remove {
-    [[TSStorageManager sharedManager]
-            .dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-      [self removeWithTransaction:transaction];
-      [[transaction ext:@"relationships"] flush];
+- (void)remove
+{
+    [[self dbConnection] readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        [self removeWithTransaction:transaction];
     }];
+}
+
+- (YapDatabaseConnection *)dbConnection
+{
+    return [[self class] dbConnection];
 }
 
 #pragma mark Class Methods
 
-+ (NSString *)collection {
++ (YapDatabaseConnection *)dbConnection
+{
+    return [TSStorageManager sharedManager].dbConnection;
+}
+
++ (NSString *)collection
+{
     return NSStringFromClass([self class]);
 }
 
-+ (instancetype)fetchObjectWithUniqueID:(NSString *)uniqueID transaction:(YapDatabaseReadTransaction *)transaction {
++ (NSUInteger)numberOfKeysInCollection
+{
+    __block NSUInteger count;
+    [[self dbConnection] readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+        count = [transaction numberOfKeysInCollection:[self collection]];
+    }];
+    return count;
+}
+
++ (NSArray *)allObjectsInCollection
+{
+    __block NSMutableArray *all = [[NSMutableArray alloc] initWithCapacity:[self numberOfKeysInCollection]];
+    [self enumerateCollectionObjectsUsingBlock:^(id object, BOOL *stop) {
+        [all addObject:object];
+    }];
+    return [all copy];
+}
+
++ (void)enumerateCollectionObjectsUsingBlock:(void (^)(id object, BOOL *stop))block
+{
+    [[self dbConnection] readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+        [self enumerateCollectionObjectsWithTransaction:transaction usingBlock:block];
+    }];
+}
+
++ (void)enumerateCollectionObjectsWithTransaction:(YapDatabaseReadTransaction *)transaction
+                                       usingBlock:(void (^)(id object, BOOL *stop))block
+{
+    // Ignoring most of the YapDB parameters, and just passing through the ones we usually use.
+    void (^yapBlock)(NSString *key, id object, id metadata, BOOL *stop)
+        = ^void(NSString *key, id object, id metadata, BOOL *stop) {
+              block(object, stop);
+          };
+
+    [transaction enumerateRowsInCollection:[self collection] usingBlock:yapBlock];
+}
+
++ (void)removeAllObjectsInCollection
+{
+    [[self dbConnection] readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        [transaction removeAllObjectsInCollection:[self collection]];
+    }];
+}
+
++ (instancetype)fetchObjectWithUniqueID:(NSString *)uniqueID transaction:(YapDatabaseReadTransaction *)transaction
+{
     return [transaction objectForKey:uniqueID inCollection:[self collection]];
 }
 
-+ (instancetype)fetchObjectWithUniqueID:(NSString *)uniqueID {
++ (instancetype)fetchObjectWithUniqueID:(NSString *)uniqueID
+{
     __block id object;
-
-    [[TSStorageManager sharedManager]
-            .dbConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
-      object = [transaction objectForKey:uniqueID inCollection:[self collection]];
+    [[self dbConnection] readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+        object = [transaction objectForKey:uniqueID inCollection:[self collection]];
     }];
-
     return object;
 }
 

--- a/src/TSConstants.h
+++ b/src/TSConstants.h
@@ -1,10 +1,5 @@
-//
-//  Constants.h
-//  TextSecureKit
-//
 //  Created by Frederic Jacobs on 28/10/14.
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
-//
 
 #import <Foundation/Foundation.h>
 @class TSNumberVerifier;

--- a/tests/Messages/Interactions/TSMessageTest.m
+++ b/tests/Messages/Interactions/TSMessageTest.m
@@ -1,6 +1,8 @@
 //  Copyright © 2016 Open Whisper Systems. All rights reserved.
 
 #import "TSMessage.h"
+#import "TSThread.h"
+#import "TSAttachment.h"
 
 #import <XCTest/XCTest.h>
 

--- a/tests/Messages/Interactions/TSMessageTest.m
+++ b/tests/Messages/Interactions/TSMessageTest.m
@@ -24,20 +24,25 @@
 
 - (void)testDescription {
     TSThread *thread = [[TSThread alloc] init];
-    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1 inThread:thread messageBody:@"My message body" attachments:nil];
+    TSMessage *message =
+        [[TSMessage alloc] initWithTimestamp:1 inThread:thread messageBody:@"My message body" attachmentIds:nil];
     XCTAssertEqualObjects(@"My message body", [message description]);
 }
 
 - (void)testDescriptionWithBogusAttachmentId {
     TSThread *thread = [[TSThread alloc] init];
-    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1 inThread:thread messageBody:@"My message body" attachments:@[@"fake-attachment-id"]];
+    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1
+                                                     inThread:thread
+                                                  messageBody:@"My message body"
+                                                attachmentIds:@[ @"fake-attachment-id" ]];
     NSString *actualDescription = [message description];
     XCTAssertEqualObjects(@"UNKNOWN_ATTACHMENT_LABEL", actualDescription);
 }
 
 - (void)testDescriptionWithEmptyAttachments {
     TSThread *thread = [[TSThread alloc] init];
-    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1 inThread:thread messageBody:@"My message body" attachments:@[]];
+    TSMessage *message =
+        [[TSMessage alloc] initWithTimestamp:1 inThread:thread messageBody:@"My message body" attachmentIds:@[]];
     NSString *actualDescription = [message description];
     XCTAssertEqualObjects(@"My message body", actualDescription);
 }
@@ -49,7 +54,10 @@
                                                             contentType:@"image/jpeg"];
     [attachment save];
 
-    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1 inThread:thread messageBody:@"My message body" attachments:@[@"fake-photo-attachment-id"]];
+    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1
+                                                     inThread:thread
+                                                  messageBody:@"My message body"
+                                                attachmentIds:@[ @"fake-photo-attachment-id" ]];
     NSString *actualDescription = [message description];
     XCTAssertEqualObjects(@"📷 ATTACHMENT", actualDescription);
 }
@@ -62,7 +70,10 @@
                                                             contentType:@"video/mp4"];
     [attachment save];
 
-    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1 inThread:thread messageBody:@"My message body" attachments:@[@"fake-video-attachment-id"]];
+    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1
+                                                     inThread:thread
+                                                  messageBody:@"My message body"
+                                                attachmentIds:@[ @"fake-video-attachment-id" ]];
     NSString *actualDescription = [message description];
     XCTAssertEqualObjects(@"📽 ATTACHMENT", actualDescription);
 }
@@ -75,7 +86,10 @@
                                                             contentType:@"audio/mp3"];
     [attachment save];
 
-    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1 inThread:thread messageBody:@"My message body" attachments:@[@"fake-audio-attachment-id"]];
+    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1
+                                                     inThread:thread
+                                                  messageBody:@"My message body"
+                                                attachmentIds:@[ @"fake-audio-attachment-id" ]];
     NSString *actualDescription = [message description];
     XCTAssertEqualObjects(@"📻 ATTACHMENT", actualDescription);
 }
@@ -87,7 +101,10 @@
                                                             contentType:@"non/sense"];
     [attachment save];
 
-    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1 inThread:thread messageBody:@"My message body" attachments:@[@"fake-nonsense-attachment-id"]];
+    TSMessage *message = [[TSMessage alloc] initWithTimestamp:1
+                                                     inThread:thread
+                                                  messageBody:@"My message body"
+                                                attachmentIds:@[ @"fake-nonsense-attachment-id" ]];
     NSString *actualDescription = [message description];
     XCTAssertEqualObjects(@"ATTACHMENT", actualDescription);
 }

--- a/tests/Messages/Interactions/TSMessageTest.m
+++ b/tests/Messages/Interactions/TSMessageTest.m
@@ -1,8 +1,8 @@
 //  Copyright © 2016 Open Whisper Systems. All rights reserved.
 
+#import "TSAttachment.h"
 #import "TSMessage.h"
 #import "TSThread.h"
-#import "TSAttachment.h"
 
 #import <XCTest/XCTest.h>
 

--- a/tests/Storage/OWSOrphanedDataCleanerTest.m
+++ b/tests/Storage/OWSOrphanedDataCleanerTest.m
@@ -1,0 +1,138 @@
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSOrphanedDataCleaner.h"
+#import "TSAttachmentStream.h"
+#import "TSContactThread.h"
+#import "TSIncomingMessage.h"
+#import "TSStorageManager.h"
+#import <XCTest/XCTest.h>
+
+@interface OWSOrphanedDataCleanerTest : XCTestCase
+
+@end
+
+@implementation OWSOrphanedDataCleanerTest
+
+- (void)setUp
+{
+    [super setUp];
+    // Register views, etc.
+    [[TSStorageManager sharedManager] setupDatabase];
+
+    // Set up initial conditions & Sanity check
+    [TSAttachmentStream deleteAttachments];
+    XCTAssertEqual(0, [TSAttachmentStream numberOfItemsInAttachmentsFolder]);
+    [TSAttachmentStream removeAllObjectsInCollection];
+    XCTAssertEqual(0, [TSAttachmentStream numberOfKeysInCollection]);
+    [TSIncomingMessage removeAllObjectsInCollection];
+    XCTAssertEqual(0, [TSIncomingMessage numberOfKeysInCollection]);
+    [TSThread removeAllObjectsInCollection];
+    XCTAssertEqual(0, [TSThread numberOfKeysInCollection]);
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)testInteractionsWithoutThreadAreDeleted
+{
+    // This thread is intentionally not saved. It's meant to recreate a situation we've seen where interactions exist
+    // that reference the id of a thread that no longer exists. Presumably this is the result of a deleted thread not
+    // properly deleting it's interactions.
+    TSContactThread *unsavedThread = [[TSContactThread alloc] initWithUniqueId:@"this-thread-does-not-exist"];
+
+    TSIncomingMessage *incomingMessage =
+        [[TSIncomingMessage alloc] initWithTimestamp:1 inThread:unsavedThread messageBody:@"footch" attachments:nil];
+    [incomingMessage save];
+    XCTAssertEqual(1, [TSIncomingMessage numberOfKeysInCollection]);
+
+    [[OWSOrphanedDataCleaner new] removeOrphanedData];
+    XCTAssertEqual(0, [TSIncomingMessage numberOfKeysInCollection]);
+}
+
+- (void)testInteractionsWithThreadAreNotDeleted
+{
+    TSContactThread *savedThread = [[TSContactThread alloc] initWithUniqueId:@"this-thread-exists"];
+    [savedThread save];
+
+    TSIncomingMessage *incomingMessage =
+        [[TSIncomingMessage alloc] initWithTimestamp:1 inThread:savedThread messageBody:@"footch" attachments:nil];
+    [incomingMessage save];
+    XCTAssertEqual(1, [TSIncomingMessage numberOfKeysInCollection]);
+
+    [[OWSOrphanedDataCleaner new] removeOrphanedData];
+    XCTAssertEqual(1, [TSIncomingMessage numberOfKeysInCollection]);
+}
+
+- (void)testFilesWithoutInteractionsAreDeleted
+{
+    TSAttachmentStream *attachmentStream = [[TSAttachmentStream alloc] initWithIdentifier:@"orphaned-attachment"
+                                                                                     data:[NSData new]
+                                                                                      key:[NSData new]
+                                                                              contentType:@"image/jpeg"];
+
+    [attachmentStream save];
+    NSString *orphanedFilePath = [attachmentStream filePath];
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:orphanedFilePath];
+    XCTAssert(fileExists);
+    XCTAssertEqual(1, [TSAttachmentStream numberOfItemsInAttachmentsFolder]);
+
+    [[OWSOrphanedDataCleaner new] removeOrphanedData];
+    fileExists = [[NSFileManager defaultManager] fileExistsAtPath:orphanedFilePath];
+    XCTAssertFalse(fileExists);
+    XCTAssertEqual(0, [TSAttachmentStream numberOfItemsInAttachmentsFolder]);
+}
+
+- (void)testFilesWithInteractionsAreNotDeleted
+{
+    TSContactThread *savedThread = [[TSContactThread alloc] initWithUniqueId:@"this-thread-exists"];
+    [savedThread save];
+
+    TSAttachmentStream *attachmentStream = [[TSAttachmentStream alloc] initWithIdentifier:@"legit-attachment"
+                                                                                     data:[NSData new]
+                                                                                      key:[NSData new]
+                                                                              contentType:@"image/jpeg"];
+    [attachmentStream save];
+
+    TSIncomingMessage *incomingMessage = [[TSIncomingMessage alloc] initWithTimestamp:1
+                                                                             inThread:savedThread
+                                                                          messageBody:@"footch"
+                                                                          attachments:@[ attachmentStream.uniqueId ]];
+    [incomingMessage save];
+
+    NSString *attachmentFilePath = [attachmentStream filePath];
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:attachmentFilePath];
+    XCTAssert(fileExists);
+    XCTAssertEqual(1, [TSAttachmentStream numberOfItemsInAttachmentsFolder]);
+
+    [[OWSOrphanedDataCleaner new] removeOrphanedData];
+
+    fileExists = [[NSFileManager defaultManager] fileExistsAtPath:attachmentFilePath];
+    XCTAssert(fileExists);
+    XCTAssertEqual(1, [TSAttachmentStream numberOfItemsInAttachmentsFolder]);
+}
+
+- (void)testFilesWithoutAttachmentStreamsAreDeleted
+{
+    TSAttachmentStream *attachmentStream = [[TSAttachmentStream alloc] initWithIdentifier:@"orphaned-attachment"
+                                                                                     data:[NSData new]
+                                                                                      key:[NSData new]
+                                                                              contentType:@"image/jpeg"];
+
+    // Intentionally not saved, because we want a lingering file.
+    // This relies on a bug(?) in the current TSAttachmentStream init implementation where the file is created during
+    // `init` rather than during `save`. If that bug is fixed, we'll have to update this test to manually create the
+    // file to set up the correct initial state.
+    NSString *orphanedFilePath = [attachmentStream filePath];
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:orphanedFilePath];
+    XCTAssert(fileExists);
+    XCTAssertEqual(1, [TSAttachmentStream numberOfItemsInAttachmentsFolder]);
+
+    [[OWSOrphanedDataCleaner new] removeOrphanedData];
+    fileExists = [[NSFileManager defaultManager] fileExistsAtPath:orphanedFilePath];
+    XCTAssertFalse(fileExists);
+    XCTAssertEqual(0, [TSAttachmentStream numberOfItemsInAttachmentsFolder]);
+}
+
+@end

--- a/tests/Storage/OWSOrphanedDataCleanerTest.m
+++ b/tests/Storage/OWSOrphanedDataCleanerTest.m
@@ -43,7 +43,7 @@
     TSContactThread *unsavedThread = [[TSContactThread alloc] initWithUniqueId:@"this-thread-does-not-exist"];
 
     TSIncomingMessage *incomingMessage =
-        [[TSIncomingMessage alloc] initWithTimestamp:1 inThread:unsavedThread messageBody:@"footch" attachments:nil];
+        [[TSIncomingMessage alloc] initWithTimestamp:1 inThread:unsavedThread messageBody:@"footch" attachmentIds:nil];
     [incomingMessage save];
     XCTAssertEqual(1, [TSIncomingMessage numberOfKeysInCollection]);
 
@@ -57,7 +57,7 @@
     [savedThread save];
 
     TSIncomingMessage *incomingMessage =
-        [[TSIncomingMessage alloc] initWithTimestamp:1 inThread:savedThread messageBody:@"footch" attachments:nil];
+        [[TSIncomingMessage alloc] initWithTimestamp:1 inThread:savedThread messageBody:@"footch" attachmentIds:nil];
     [incomingMessage save];
     XCTAssertEqual(1, [TSIncomingMessage numberOfKeysInCollection]);
 
@@ -98,7 +98,7 @@
     TSIncomingMessage *incomingMessage = [[TSIncomingMessage alloc] initWithTimestamp:1
                                                                              inThread:savedThread
                                                                           messageBody:@"footch"
-                                                                          attachments:@[ attachmentStream.uniqueId ]];
+                                                                        attachmentIds:@[ attachmentStream.uniqueId ]];
     [incomingMessage save];
 
     NSString *attachmentFilePath = [attachmentStream filePath];

--- a/tests/Storage/TSMessageStorageTests.m
+++ b/tests/Storage/TSMessageStorageTests.m
@@ -159,13 +159,17 @@
 
     __block TSGroupThread *thread;
     [[TSStorageManager sharedManager].dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-        thread = [TSGroupThread getOrCreateThreadWithGroupModel:[[TSGroupModel alloc] initWithTitle:@"fdsfsd" memberIds:[@[] mutableCopy] image:nil groupId:[NSData data] associatedAttachmentId:pointer.uniqueId] transaction:transaction];
-        
+        thread = [TSGroupThread getOrCreateThreadWithGroupModel:[[TSGroupModel alloc] initWithTitle:@"fdsfsd"
+                                                                                          memberIds:[@[] mutableCopy]
+                                                                                              image:nil
+                                                                                            groupId:[NSData data]]
+                                                    transaction:transaction];
+
         [thread saveWithTransaction:transaction];
         [pointer saveWithTransaction:transaction];
 
     }];
-    
+
     TSStorageManager *manager         = [TSStorageManager sharedManager];
     [manager purgeCollection:[TSMessage collection]];
     

--- a/tests/Storage/TSMessageStorageTests.m
+++ b/tests/Storage/TSMessageStorageTests.m
@@ -27,7 +27,8 @@
 
 @implementation TSMessageStorageTests
 
-- (void)setUp {
+- (void)setUp
+{
     [super setUp];
     
     [[TSStorageManager sharedManager].dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
@@ -40,12 +41,14 @@
     [manager purgeCollection:[TSMessage collection]];
 }
 
-- (void)tearDown {
+- (void)tearDown
+{
     // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
 }
 
-- (void)testIncrementalMessageNumbers{
+- (void)testIncrementalMessageNumbers
+{
     __block NSInteger messageInt;
     NSString *body = @"I don't see myself as a hero because what I'm doing is self-interested: I don't want to live in a world where there's no privacy and therefore no room for intellectual exploration and creativity.";
     [[TSStorageManager sharedManager].newDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
@@ -53,13 +56,11 @@
         NSString* messageId;
         
         for (uint64_t i = 0; i<50; i++) {
-            TSIncomingMessage *newMessage = [[TSIncomingMessage alloc] initWithTimestamp:i
-                                                                                inThread:self.thread
-                                                                             messageBody:body
-                                                                             attachments:nil];
-             [newMessage saveWithTransaction:transaction];
-             if (i == 0) {
-                 messageId = newMessage.uniqueId;
+            TSIncomingMessage *newMessage =
+                [[TSIncomingMessage alloc] initWithTimestamp:i inThread:self.thread messageBody:body attachmentIds:nil];
+            [newMessage saveWithTransaction:transaction];
+            if (i == 0) {
+                messageId = newMessage.uniqueId;
              }
         }
         
@@ -80,7 +81,7 @@
         TSIncomingMessage *newMessage = [[TSIncomingMessage alloc] initWithTimestamp:uniqueNewTimestamp
                                                                             inThread:self.thread
                                                                          messageBody:body
-                                                                         attachments:nil];
+                                                                       attachmentIds:nil];
         [newMessage saveWithTransaction:transaction];
         
         TSIncomingMessage *retrieved = [TSIncomingMessage fetchObjectWithUniqueID:[@(messageInt+50) stringValue] transaction:transaction];
@@ -88,16 +89,15 @@
     }];
 }
 
-- (void)testStoreIncomingMessage {
+- (void)testStoreIncomingMessage
+{
     __block NSString *messageId;
     uint64_t timestamp = 666;
     
     NSString *body = @"A child born today will grow up with no conception of privacy at all. They’ll never know what it means to have a private moment to themselves an unrecorded, unanalyzed thought. And that’s a problem because privacy matters; privacy is what allows us to determine who we are and who we want to be.";
-    
-    TSIncomingMessage *newMessage = [[TSIncomingMessage alloc] initWithTimestamp:timestamp
-                                                                        inThread:self.thread
-                                                                     messageBody:body
-                                                                     attachments:nil];
+
+    TSIncomingMessage *newMessage =
+        [[TSIncomingMessage alloc] initWithTimestamp:timestamp inThread:self.thread messageBody:body attachmentIds:nil];
     [[TSStorageManager sharedManager].newDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         [newMessage saveWithTransaction:transaction];
         messageId = newMessage.uniqueId;
@@ -106,21 +106,20 @@
     TSIncomingMessage *fetchedMessage = [TSIncomingMessage fetchObjectWithUniqueID:messageId];
     
     NSAssert([fetchedMessage.body isEqualToString:body], @"Body of incoming message recovered");
-    NSAssert(fetchedMessage.attachments == nil, @"attachments are nil");
+    NSAssert(fetchedMessage.attachmentIds == nil, @"attachments are nil");
     NSAssert(fetchedMessage.timestamp == timestamp, @"Unique identifier is accurate");
     NSAssert(fetchedMessage.wasRead == false, @"Message should originally be unread");
     NSAssert([fetchedMessage.uniqueThreadId isEqualToString:self.thread.uniqueId], @"Isn't stored in the right thread!");
 }
 
-- (void)testMessagesDeletedOnThreadDeletion {
+- (void)testMessagesDeletedOnThreadDeletion
+{
     uint64_t timestamp = 666;
     NSString *body = @"A child born today will grow up with no conception of privacy at all. They’ll never know what it means to have a private moment to themselves an unrecorded, unanalyzed thought. And that’s a problem because privacy matters; privacy is what allows us to determine who we are and who we want to be.";
     
     for (uint64_t i = timestamp; i<100; i++) {
-        TSIncomingMessage *newMessage = [[TSIncomingMessage alloc] initWithTimestamp:i
-                                                                            inThread:self.thread
-                                                                         messageBody:body
-                                                                         attachments:nil];
+        TSIncomingMessage *newMessage =
+            [[TSIncomingMessage alloc] initWithTimestamp:i inThread:self.thread messageBody:body attachmentIds:nil];
         [newMessage save];
     }
     
@@ -131,7 +130,7 @@
             TSIncomingMessage *fetchedMessage = [TSIncomingMessage fetchObjectWithUniqueID:[TSInteraction stringFromTimeStamp:timestamp] transaction:transaction];
             
             NSAssert([fetchedMessage.body isEqualToString:body], @"Body of incoming message recovered");
-            NSAssert(fetchedMessage.attachments == nil, @"attachments are nil");
+            NSAssert(fetchedMessage.attachmentIds == nil, @"attachments are nil");
             NSAssert([fetchedMessage.uniqueId isEqualToString:[TSInteraction stringFromTimeStamp:timestamp]], @"Unique identifier is accurate");
             NSAssert(fetchedMessage.wasRead == false, @"Message should originally be unread");
             NSAssert([fetchedMessage.uniqueThreadId isEqualToString:self.thread.uniqueId], @"Isn't stored in the right thread!");
@@ -150,7 +149,8 @@
 }
 
 
-- (void)testGroupMessagesDeletedOnThreadDeletion {
+- (void)testGroupMessagesDeletedOnThreadDeletion
+{
     uint64_t timestamp = 666;
     NSString *body = @"A child born today will grow up with no conception of privacy at all. They’ll never know what it means to have a private moment to themselves an unrecorded, unanalyzed thought. And that’s a problem because privacy matters; privacy is what allows us to determine who we are and who we want to be.";
     
@@ -170,8 +170,12 @@
     [manager purgeCollection:[TSMessage collection]];
     
     for (uint64_t i = timestamp; i<100; i++) {
-        TSIncomingMessage *newMessage = [[TSIncomingMessage alloc] initWithTimestamp:i inThread:thread authorId:@"Ed" messageBody:body attachments:nil];
-        
+        TSIncomingMessage *newMessage = [[TSIncomingMessage alloc] initWithTimestamp:i
+                                                                            inThread:thread
+                                                                            authorId:@"Ed"
+                                                                         messageBody:body
+                                                                       attachmentIds:nil];
+
         [newMessage save];
     }
     
@@ -185,7 +189,7 @@
             
             
             NSAssert([fetchedMessage.body isEqualToString:body], @"Body of incoming message recovered");
-            NSAssert(fetchedMessage.attachments == nil, @"attachments are nil");
+            NSAssert(fetchedMessage.attachmentIds == nil, @"attachments are nil");
             NSAssert([fetchedMessage.uniqueId isEqualToString:[TSInteraction stringFromTimeStamp:timestamp]], @"Unique identifier is accurate");
             NSAssert(fetchedMessage.wasRead == false, @"Message should originally be unread");
             NSAssert([fetchedMessage.uniqueThreadId isEqualToString:self.thread.uniqueId], @"Isn't stored in the right thread!");


### PR DESCRIPTION
## Description

Ensures a deleted thread actually deletes it's interactions and attachments. Also a cleanup helper to remove any dangling interactions and attachments hanging around after their thread has been deleted.
## Motivation

Occasionally we are seeing messages from deleted threads reappear in new threads. Spooky stuff. :eyes:

This is because though the thread is deleted, some of the thread's interactions are not, leaving them with a dangling reference to the thread's contact ID. When the thread is recreated, the references are no longer dangling, and they reappear in the thread.

This could also cause any large attachments associated with those lingering interactions to hang around after the thread was deleted.

Previously for this cascading delete behavior we relied on the YapDatabase "relationship" extension to build an object graph and delete objects when there weren't accessible, as inferred by reference counting edges to the object. This all sounds nice in theory, but introduces a lot of complex machinery under the covers, when what we _really_ want is pretty simple:
1. Upon deleting a thread, the thread deletes all it's interactions.
2. If the deleted interaction represents media with an attachment on disk, delete the file.

In the end, it's a lot less magical to just spell those things out.

Also:
- enabled compiler warnings for test app
- convenience methods added to our base TSYapDatabaseObject to make testing easier
- renamed confusing api
