### PR TITLE
Avoid collision with iOS10 SSKeychain framework

### DIFF
--- a/Example/TSKitiOSTestApp/Podfile.lock
+++ b/Example/TSKitiOSTestApp/Podfile.lock
@@ -34,22 +34,22 @@ PODS:
   - Mantle/extobjc (2.0.7)
   - ProtocolBuffers (1.9.10)
   - Reachability (3.2)
-  - SignalServiceKit (0.0.7):
+  - SAMKeychain (1.5.0)
+  - SignalServiceKit (0.0.8):
     - '25519'
     - AFNetworking
     - AxolotlKit
     - CocoaLumberjack
     - libPhoneNumber-iOS
     - Mantle
+    - SAMKeychain
     - SocketRocket
-    - SSKeychain
     - TwistedOakCollapsingFutures
     - YapDatabase/SQLCipher
   - SocketRocket (0.5.1)
   - SQLCipher/common (3.4.0)
   - SQLCipher/fts (3.4.0):
     - SQLCipher/common
-  - SSKeychain (1.4.0)
   - TwistedOakCollapsingFutures (1.0.0):
     - UnionFind (~> 1.0)
   - UnionFind (1.0.1)
@@ -129,10 +129,10 @@ SPEC CHECKSUMS:
   Mantle: bc40bb061d8c2c6fb48d5083e04d928c3b7f73d9
   ProtocolBuffers: d088180c10072b3d24a9939a6314b7b9bcc2340b
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  SignalServiceKit: e0bc81d12cef07b621403ff49e1c9c6f64d96109
+  SAMKeychain: 1fc9ae02f576365395758b12888c84704eebc423
+  SignalServiceKit: 9bdacbb1cb046836e9d601273fa4fad934ad3ecb
   SocketRocket: 3f77ec2104cc113add553f817ad90a77114f5d43
   SQLCipher: 4c768761421736a247ed6cf412d9045615d53dff
-  SSKeychain: c71293fa57216a40ab06c23f4085387583293de4
   TwistedOakCollapsingFutures: f359b90f203e9ab13dfb92c9ff41842a7fe1cd0c
   UnionFind: c33be5adb12983981d6e827ea94fc7f9e370f52d
   YapDatabase: c00f4197bba2fea17bdbd82c8e8e3f7104b6fa67

--- a/SignalServiceKit.podspec
+++ b/SignalServiceKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SignalServiceKit"
-  s.version          = "0.0.7"
+  s.version          = "0.0.8"
   s.summary          = "An Objective-C library for communicating with the Signal messaging service."
 
   s.description      = <<-DESC
@@ -42,6 +42,6 @@ An Objective-C library for communicating with the Signal messaging service.
   # see Example/TSKitiOSTestApp/Podfile for details
   s.dependency 'SocketRocket'
   s.dependency 'libPhoneNumber-iOS'
-  s.dependency 'SSKeychain'
+  s.dependency 'SAMKeychain'
   s.dependency 'TwistedOakCollapsingFutures'
 end


### PR DESCRIPTION
Our pod SSKeychain was renamed to -> SAMKeychain to avoid collision with
the iOS10 library SSKeychain.
- log failure to write keychain (this seems to only happen on simulator)
- ensure we exit if we fail to set DB cipher key

// FREEBIE
