### PR TITLE
Fix multiple keychange errors

### DIFF
--- a/src/Contacts/TSThread.m
+++ b/src/Contacts/TSThread.m
@@ -131,6 +131,19 @@ NS_ASSUME_NONNULL_BEGIN
     }];
 }
 
+/**
+ * Useful for tests and debugging. In production use an enumeration method.
+ */
+- (NSArray<TSInteraction *> *)allInteractions
+{
+    NSMutableArray<TSInteraction *> *interactions = [NSMutableArray new];
+    [self enumerateInteractionsUsingBlock:^(TSInteraction *_Nonnull interaction) {
+        [interactions addObject:interaction];
+    }];
+
+    return [interactions copy];
+}
+
 - (NSArray<TSInvalidIdentityKeyReceivingErrorMessage *> *)receivedMessagesForInvalidKey:(NSData *)key
 {
     NSMutableArray *errorMessages = [NSMutableArray new];

--- a/src/Messages/Interactions/TSMessage.m
+++ b/src/Messages/Interactions/TSMessage.m
@@ -103,7 +103,7 @@ static const NSUInteger OWSMessageSchemaVersion = 2;
         NSString *attachmentId = self.attachmentIds[0];
         return [NSString stringWithFormat:@"Media Message with attachmentId:%@", attachmentId];
     } else {
-        return [NSString stringWithFormat:@"Message with body:%@", self.body];
+        return [NSString stringWithFormat:@"%@ with body:%@", [self class], self.body];
     }
 }
 

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -478,26 +478,26 @@
     DDLogWarn(@"Got exception: %@", exception.description);
 
     [self.dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-      TSErrorMessage *errorMessage;
+        TSErrorMessage *errorMessage;
 
-      if ([exception.name isEqualToString:UntrustedIdentityKeyException]) {
-          errorMessage = [TSInvalidIdentityKeySendingErrorMessage
-              untrustedKeyWithOutgoingMessage:message
-                                     inThread:thread
-                                 forRecipient:exception.userInfo[TSInvalidRecipientKey]
-                                 preKeyBundle:exception.userInfo[TSInvalidPreKeyBundleKey]
-                              withTransaction:transaction];
-          message.messageState = TSOutgoingMessageStateUnsent;
-          [message saveWithTransaction:transaction];
-      } else if (message.groupMetaMessage == TSGroupMessageNone) {
-          // Only update this with exception if it is not a group message as group
-          // messages may except for one group
-          // send but not another and the UI doesn't know how to handle that
-          [message setMessageState:TSOutgoingMessageStateUnsent];
-          [message saveWithTransaction:transaction];
-      }
+        if ([exception.name isEqualToString:UntrustedIdentityKeyException]) {
+            errorMessage = [TSInvalidIdentityKeySendingErrorMessage
+                untrustedKeyWithOutgoingMessage:message
+                                       inThread:thread
+                                   forRecipient:exception.userInfo[TSInvalidRecipientKey]
+                                   preKeyBundle:exception.userInfo[TSInvalidPreKeyBundleKey]
+                                withTransaction:transaction];
+            message.messageState = TSOutgoingMessageStateUnsent;
+            [message saveWithTransaction:transaction];
+        } else if (message.groupMetaMessage == TSGroupMessageNone) {
+            // Only update this with exception if it is not a group message as group
+            // messages may except for one group
+            // send but not another and the UI doesn't know how to handle that
+            [message setMessageState:TSOutgoingMessageStateUnsent];
+            [message saveWithTransaction:transaction];
+        }
 
-      [errorMessage saveWithTransaction:transaction];
+        [errorMessage saveWithTransaction:transaction];
     }];
 }
 


### PR DESCRIPTION
- Don't attempt to send a message unless we've successfully built a device-messages
- Only process message exception when we're done with retries.

// FREEBIE
