### PR TITLE
Fix timeout on launch for some users

### DIFF
--- a/src/Devices/OWSReadReceipt.h
+++ b/src/Devices/OWSReadReceipt.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithSenderId:(NSString *)senderId timestamp:(uint64_t)timestamp;
 
 + (nullable instancetype)firstWithSenderId:(NSString *)senderId timestamp:(uint64_t)timestamp;
-+ (void)registerIndexOnSenderIdAndTimestampWithDatabase:(YapDatabase *)database;
++ (void)asyncRegisterIndexOnSenderIdAndTimestampWithDatabase:(YapDatabase *)database;
 
 @end
 

--- a/src/Storage/TSDatabaseView.h
+++ b/src/Storage/TSDatabaseView.h
@@ -24,6 +24,6 @@ extern NSString *TSSecondaryDevicesDatabaseViewExtensionName;
 + (BOOL)registerThreadDatabaseView;
 + (BOOL)registerBuddyConversationDatabaseView;
 + (BOOL)registerUnreadDatabaseView;
-+ (BOOL)registerSecondaryDevicesDatabaseView;
++ (void)asyncRegisterSecondaryDevicesDatabaseView;
 
 @end


### PR DESCRIPTION
This would especially affect users with large databases on older
devices.

Some of these database extensions aren't strictly necessary to launch
the app. Theoretically we could see weird read receipt behavior for
the initial 10-30 seconds after the app is launched for first time.

// FREEBIE
