### PR TITLE
Maps numbers to names in TSGroupModel

### DIFF
--- a/src/Messages/Interactions/TSOutgoingMessage.h
+++ b/src/Messages/Interactions/TSOutgoingMessage.h
@@ -46,6 +46,7 @@ typedef NS_ENUM(NSInteger, TSOutgoingMessageState) {
 
 @property (nonatomic) TSOutgoingMessageState messageState;
 @property BOOL hasSyncedTranscript;
+@property NSString *customMessage;
 
 /**
  * Signal Identifier (e.g. e164 number) or nil if in a group thread.

--- a/src/Messages/TSGroupModel.h
+++ b/src/Messages/TSGroupModel.h
@@ -2,6 +2,7 @@
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
 
 #import "TSYapDatabaseObject.h"
+#import "ContactsManagerProtocol.h"
 
 @interface TSGroupModel : TSYapDatabaseObject
 
@@ -19,7 +20,7 @@
 
 - (BOOL)isEqual:(id)other;
 - (BOOL)isEqualToGroupModel:(TSGroupModel *)model;
-- (NSString *)getInfoStringAboutUpdateTo:(TSGroupModel *)model;
+- (NSString *)getInfoStringAboutUpdateTo:(TSGroupModel *)model withContactsManager:(id<ContactsManagerProtocol>)contactsManager;
 #endif
 
 

--- a/src/Messages/TSGroupModel.h
+++ b/src/Messages/TSGroupModel.h
@@ -20,7 +20,7 @@
 
 - (BOOL)isEqual:(id)other;
 - (BOOL)isEqualToGroupModel:(TSGroupModel *)model;
-- (NSString *)getInfoStringAboutUpdateTo:(TSGroupModel *)model withContactsManager:(id<ContactsManagerProtocol>)contactsManager;
+- (NSString *)getInfoStringAboutUpdateTo:(TSGroupModel *)model contactsManager:(id<ContactsManagerProtocol>)contactsManager;
 #endif
 
 

--- a/src/Messages/TSGroupModel.m
+++ b/src/Messages/TSGroupModel.m
@@ -51,7 +51,7 @@
     return YES;
 }
 
-- (NSString *)getInfoStringAboutUpdateTo:(TSGroupModel *)newModel withContactsManager:(id<ContactsManagerProtocol>)contactsManager {
+- (NSString *)getInfoStringAboutUpdateTo:(TSGroupModel *)newModel contactsManager:(id<ContactsManagerProtocol>)contactsManager {
     NSString *updatedGroupInfoString = @"";
     if (self == newModel) {
         return NSLocalizedString(@"GROUP_UPDATED", @"");
@@ -86,7 +86,13 @@
         updatedGroupInfoString = [updatedGroupInfoString
             stringByAppendingString:[NSString
                                         stringWithFormat:NSLocalizedString(@"GROUP_MEMBER_LEFT", @""),
+                                                         [[membersWhoLeft allObjects] componentsJoinedByString:@", "]]];
+            stringByAppendingString:[NSString
+                                        stringWithFormat:NSLocalizedString(@"GROUP_MEMBER_LEFT", @""),
                                                          [oldMembersNames componentsJoinedByString:@", "]]];
+                                  stringByAppendingString:[NSString
+                                                           stringWithFormat:NSLocalizedString(@"GROUP_MEMBER_LEFT", @""),
+                                                           [oldMembersNames componentsJoinedByString:@", "]]];
     }
 
     if ([membersWhoJoined count] > 0) {
@@ -95,7 +101,12 @@
         }];
         updatedGroupInfoString = [updatedGroupInfoString
             stringByAppendingString:[NSString stringWithFormat:NSLocalizedString(@"GROUP_MEMBER_JOINED", @""),
+                                                               [[membersWhoJoined allObjects]
+                                                                   componentsJoinedByString:@", "]]];
+            stringByAppendingString:[NSString stringWithFormat:NSLocalizedString(@"GROUP_MEMBER_JOINED", @""),
                                                                [newMembersNames componentsJoinedByString:@", "]]];
+                                  stringByAppendingString:[NSString stringWithFormat:NSLocalizedString(@"GROUP_MEMBER_JOINED", @""),
+                                                           [newMembersNames componentsJoinedByString:@", "]]];
     }
 
     return updatedGroupInfoString;

--- a/src/Messages/TSGroupModel.m
+++ b/src/Messages/TSGroupModel.m
@@ -2,6 +2,7 @@
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
 
 #import "TSGroupModel.h"
+#import "FunctionalUtil.h"
 
 @implementation TSGroupModel
 
@@ -50,7 +51,7 @@
     return YES;
 }
 
-- (NSString *)getInfoStringAboutUpdateTo:(TSGroupModel *)newModel {
+- (NSString *)getInfoStringAboutUpdateTo:(TSGroupModel *)newModel withContactsManager:(id<ContactsManagerProtocol>)contactsManager {
     NSString *updatedGroupInfoString = @"";
     if (self == newModel) {
         return NSLocalizedString(@"GROUP_UPDATED", @"");
@@ -79,17 +80,22 @@
 
 
     if ([membersWhoLeft count] > 0) {
+        NSArray *oldMembersNames = [[membersWhoLeft allObjects] map:^NSString*(NSString* item) {
+            return [contactsManager nameStringForPhoneIdentifier:item];
+        }];
         updatedGroupInfoString = [updatedGroupInfoString
             stringByAppendingString:[NSString
                                         stringWithFormat:NSLocalizedString(@"GROUP_MEMBER_LEFT", @""),
-                                                         [[membersWhoLeft allObjects] componentsJoinedByString:@", "]]];
+                                                         [oldMembersNames componentsJoinedByString:@", "]]];
     }
 
     if ([membersWhoJoined count] > 0) {
+        NSArray *newMembersNames = [[membersWhoJoined allObjects] map:^NSString*(NSString* item) {
+            return [contactsManager nameStringForPhoneIdentifier:item];
+        }];
         updatedGroupInfoString = [updatedGroupInfoString
             stringByAppendingString:[NSString stringWithFormat:NSLocalizedString(@"GROUP_MEMBER_JOINED", @""),
-                                                               [[membersWhoJoined allObjects]
-                                                                   componentsJoinedByString:@", "]]];
+                                                               [newMembersNames componentsJoinedByString:@", "]]];
     }
 
     return updatedGroupInfoString;

--- a/src/Messages/TSMessagesManager+sendMessages.m
+++ b/src/Messages/TSMessagesManager+sendMessages.m
@@ -583,14 +583,16 @@ dispatch_queue_t sendingQueue() {
 
           [[[TSInfoMessage alloc] initWithTimestamp:message.timestamp
                                            inThread:thread
-                                        messageType:TSInfoMessageTypeGroupQuit] saveWithTransaction:transaction];
+                                        messageType:TSInfoMessageTypeGroupQuit
+                                      customMessage:message.customMessage] saveWithTransaction:transaction];
         }];
     } else {
         [self.dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
 
           [[[TSInfoMessage alloc] initWithTimestamp:message.timestamp
                                            inThread:thread
-                                        messageType:TSInfoMessageTypeGroupUpdate] saveWithTransaction:transaction];
+                                        messageType:TSInfoMessageTypeGroupUpdate
+                                      customMessage:message.customMessage] saveWithTransaction:transaction];
         }];
     }
 }

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -412,7 +412,7 @@ NS_ASSUME_NONNULL_BEGIN
                   }
               }
 
-              NSString *updateGroupInfo = [gThread.groupModel getInfoStringAboutUpdateTo:model withContactsManager:self.contactsManager];
+              NSString *updateGroupInfo = [gThread.groupModel getInfoStringAboutUpdateTo:model contactsManager:self.contactsManager];
               gThread.groupModel        = model;
               [gThread saveWithTransaction:transaction];
               [[[TSInfoMessage alloc] initWithTimestamp:timestamp

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -412,7 +412,7 @@ NS_ASSUME_NONNULL_BEGIN
                   }
               }
 
-              NSString *updateGroupInfo = [gThread.groupModel getInfoStringAboutUpdateTo:model];
+              NSString *updateGroupInfo = [gThread.groupModel getInfoStringAboutUpdateTo:model withContactsManager:self.contactsManager];
               gThread.groupModel        = model;
               [gThread saveWithTransaction:transaction];
               [[[TSInfoMessage alloc] initWithTimestamp:timestamp


### PR DESCRIPTION
# Use an injected ContactsManager to look up proper user names for phone numbers in [TSGroupModel getInfoStringAboutUpdateTo].

Fixes WhisperSystems/Signal-iOS#757

// FREEBIE
