### PR TITLE
Fix disappearing messages don't become consistent after reinstall

### DIFF
--- a/src/Contacts/OWSDisappearingMessagesConfiguration.h
+++ b/src/Contacts/OWSDisappearingMessagesConfiguration.h
@@ -20,7 +20,10 @@ extern const uint32_t OWSDisappearingMessagesConfigurationDefaultExpirationDurat
 @property (nonatomic, readonly) BOOL dictionaryValueDidChange;
 @property (readonly, getter=isNewRecord) BOOL newRecord;
 
++ (instancetype)fetchOrCreateDefaultWithThreadId:(NSString *)threadId;
+
 + (NSArray<NSNumber *> *)validDurationsSeconds;
+
 + (NSString *)stringForDurationSeconds:(uint32_t)durationSeconds;
 
 @end

--- a/src/Contacts/OWSDisappearingMessagesConfiguration.m
+++ b/src/Contacts/OWSDisappearingMessagesConfiguration.m
@@ -49,6 +49,16 @@ const uint32_t OWSDisappearingMessagesConfigurationDefaultExpirationDuration = 6
     return self;
 }
 
++ (instancetype)fetchOrCreateDefaultWithThreadId:(NSString *)threadId
+{
+    OWSDisappearingMessagesConfiguration *savedConfiguration = [self fetchObjectWithUniqueID:threadId];
+    if (savedConfiguration) {
+        return savedConfiguration;
+    } else {
+        return [[self alloc] initDefaultWithThreadId:threadId];
+    }
+}
+
 + (NSString *)stringForDurationSeconds:(uint32_t)durationSeconds
 {
     NSString *amountFormat;

--- a/src/Messages/OWSDisappearingMessagesJob.m
+++ b/src/Messages/OWSDisappearingMessagesJob.m
@@ -164,7 +164,7 @@ NS_ASSUME_NONNULL_BEGIN
     // Become eventually consistent in the case that the remote changed their settings at the same time.
     // Also in case remote doesn't support expiring messages
     OWSDisappearingMessagesConfiguration *disappearingMessagesConfiguration =
-        [OWSDisappearingMessagesConfiguration fetchObjectWithUniqueID:message.uniqueThreadId];
+        [OWSDisappearingMessagesConfiguration fetchOrCreateDefaultWithThreadId:message.uniqueThreadId];
 
     BOOL changed = NO;
     if (message.expiresInSeconds == 0) {


### PR DESCRIPTION
Fixes the bug wherein:

Given the sender had disappearing messages enabled
And the receiver thinks it's disabled (this can happen due to re-install)
When we receive a disappearing message
The message does start expiring timer and disappear
But you see a notice "<sender> disabled disappearing messages"
Rather than the expected "<Sender> set disappearing messages timer to X".

// FREEBIE
