### PR TITLE
Don't send empty message to self after changing disappearing timer

### DIFF
--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -549,6 +549,14 @@ NSString *const OWSMessageSenderInvalidDeviceException = @"InvalidDeviceExceptio
 
 - (void)handleSendToMyself:(TSOutgoingMessage *)outgoingMessage
 {
+    [self handleMessageSentLocally:outgoingMessage];
+
+    if (!(outgoingMessage.body || outgoingMessage.hasAttachments)) {
+        DDLogDebug(
+            @"%@ Refusing to make incoming copy of non-standard message sent to self:%@", self.tag, outgoingMessage);
+        return;
+    }
+
     [self.dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
         TSContactThread *cThread =
             [TSContactThread getOrCreateThreadWithContactId:[TSAccountManager localNumber] transaction:transaction];
@@ -562,7 +570,6 @@ NSString *const OWSMessageSenderInvalidDeviceException = @"InvalidDeviceExceptio
                                         expiresInSeconds:outgoingMessage.expiresInSeconds];
         [incomingMessage saveWithTransaction:transaction];
     }];
-    [self handleMessageSentLocally:outgoingMessage];
 }
 
 - (void)sendSyncTranscriptForMessage:(TSOutgoingMessage *)message


### PR DESCRIPTION
previously fixed in: 91fcd01632a81f2aa67d2d94b97c68d519e6881a

But lost in a rebase after moving TSMessagesManager+sendMessage to OWSMessageSender.

// FREEBIE
