### PR TITLE
Fix register w/o background fetch & stale push tokens

### DIFF
--- a/Example/TSKitiOSTestApp/Podfile.lock
+++ b/Example/TSKitiOSTestApp/Podfile.lock
@@ -35,7 +35,7 @@ PODS:
   - ProtocolBuffers (1.9.10)
   - Reachability (3.2)
   - SAMKeychain (1.5.0)
-  - SignalServiceKit (0.3.0):
+  - SignalServiceKit (0.4.0):
     - '25519'
     - AFNetworking
     - AxolotlKit
@@ -130,7 +130,7 @@ SPEC CHECKSUMS:
   ProtocolBuffers: d088180c10072b3d24a9939a6314b7b9bcc2340b
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SAMKeychain: 1fc9ae02f576365395758b12888c84704eebc423
-  SignalServiceKit: 8b115cfd63f9b814fa03fe61fd5d38ef9a548460
+  SignalServiceKit: 5c3877241082a778c8c130e1fed17d0904085205
   SocketRocket: 3f77ec2104cc113add553f817ad90a77114f5d43
   SQLCipher: 4c768761421736a247ed6cf412d9045615d53dff
   TwistedOakCollapsingFutures: f359b90f203e9ab13dfb92c9ff41842a7fe1cd0c

--- a/SignalServiceKit.podspec
+++ b/SignalServiceKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SignalServiceKit"
-  s.version          = "0.3.0"
+  s.version          = "0.4.0"
   s.summary          = "An Objective-C library for communicating with the Signal messaging service."
 
   s.description      = <<-DESC

--- a/src/Account/TSAccountManager.h
+++ b/src/Account/TSAccountManager.h
@@ -9,12 +9,20 @@
 #import <Foundation/Foundation.h>
 #import "TSConstants.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 static NSString *const TSRegistrationErrorDomain             = @"TSRegistrationErrorDomain";
 static NSString *const TSRegistrationErrorUserInfoHTTPStatus = @"TSHTTPStatus";
 
-typedef void (^failedBlock)(NSError *error);
+@class TSNetworkManager;
+@class TSStorageManager;
 
 @interface TSAccountManager : NSObject
+
+- (instancetype)initWithNetworkManager:(TSNetworkManager *)networkManager
+                        storageManager:(TSStorageManager *)storageManager;
+
++ (instancetype)sharedInstance;
 
 /**
  *  Returns if a user is registered or not
@@ -22,17 +30,15 @@ typedef void (^failedBlock)(NSError *error);
  *  @return registered or not
  */
 + (BOOL)isRegistered;
-+ (void)runIfRegistered:(void (^)())block;
+
+- (void)ifRegistered:(BOOL)isRegistered runAsync:(void (^)())block;
 
 /**
  *  Returns registered number
  *
  *  @return E164 formatted phone number
  */
-
-+ (NSString *)localNumber;
-
-+ (void)didRegister;
++ (nullable NSString *)localNumber;
 
 /**
  *  The registration ID is unique to an installation of TextSecure, it allows to know if the app was reinstalled
@@ -45,19 +51,17 @@ typedef void (^failedBlock)(NSError *error);
 #pragma mark - Register with phone number
 
 + (void)registerWithPhoneNumber:(NSString *)phoneNumber
-                        success:(successCompletionBlock)successBlock
-                        failure:(failedBlock)failureBlock
+                        success:(void (^)())successBlock
+                        failure:(void (^)(NSError *error))failureBlock
                 smsVerification:(BOOL)isSMS;
 
-+ (void)rerequestSMSWithSuccess:(successCompletionBlock)successBlock failure:(failedBlock)failureBlock;
++ (void)rerequestSMSWithSuccess:(void (^)())successBlock failure:(void (^)(NSError *error))failureBlock;
 
-+ (void)rerequestVoiceWithSuccess:(successCompletionBlock)successBlock failure:(failedBlock)failureBlock;
++ (void)rerequestVoiceWithSuccess:(void (^)())successBlock failure:(void (^)(NSError *error))failureBlock;
 
-+ (void)verifyAccountWithCode:(NSString *)verificationCode
-                    pushToken:(NSString *)pushToken
-                    voipToken:(NSString *)voipToken
-                      success:(successCompletionBlock)successBlock
-                      failure:(failedBlock)failureBlock;
+- (void)verifyAccountWithCode:(NSString *)verificationCode
+                      success:(void (^)())successBlock
+                      failure:(void (^)(NSError *error))failureBlock;
 
 #if TARGET_OS_IPHONE
 
@@ -66,16 +70,19 @@ typedef void (^failedBlock)(NSError *error);
  *
  *  @param pushToken Apple's Push Token
  */
+- (void)registerForPushNotificationsWithPushToken:(NSString *)pushToken
+                                        voipToken:(NSString *)voipToken
+                                          success:(void (^)())successHandler
+                                          failure:(void (^)(NSError *error))failureHandler
+    NS_SWIFT_NAME(registerForPushNotifications(pushToken:voipToken:success:failure:));
 
-+ (void)registerForPushNotifications:(NSString *)pushToken
-                           voipToken:(NSString *)voipToken
-                             success:(successCompletionBlock)success
-                             failure:(failedBlock)failureBlock;
-
-+ (void)obtainRPRegistrationToken:(void (^)(NSString *rpRegistrationToken))success failure:(failedBlock)failureBlock;
+- (void)obtainRPRegistrationTokenWithSuccess:(void (^)(NSString *rpRegistrationToken))success
+                                     failure:(void (^)(NSError *error))failureBlock;
 
 #endif
 
-+ (void)unregisterTextSecureWithSuccess:(successCompletionBlock)success failure:(failedBlock)failureBlock;
++ (void)unregisterTextSecureWithSuccess:(void (^)())success failure:(void (^)(NSError *error))failureBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/Account/TSPreKeyManager.h
+++ b/src/Account/TSPreKeyManager.h
@@ -8,14 +8,13 @@
 
 #import <Foundation/Foundation.h>
 #import "TSAccountManager.h"
-#import "TSConstants.h"
 
 // Time before deletion of signed PreKeys (measured in seconds)
 #define SignedPreKeysDeletionTime 14 * 24 * 60 * 60
 
 @interface TSPreKeyManager : NSObject
 
-+ (void)registerPreKeysWithSuccess:(successCompletionBlock)success failure:(failedBlock)failureBlock;
++ (void)registerPreKeysWithSuccess:(void (^)())successHandler failure:(void (^)(NSError *error))failureHandler;
 
 + (void)refreshPreKeys;
 

--- a/src/Account/TSPreKeyManager.m
+++ b/src/Account/TSPreKeyManager.m
@@ -16,7 +16,8 @@
 
 @implementation TSPreKeyManager
 
-+ (void)registerPreKeysWithSuccess:(successCompletionBlock)success failure:(failedBlock)failureBlock {
++ (void)registerPreKeysWithSuccess:(void (^)())success failure:(void (^)(NSError *))failureBlock
+{
     TSStorageManager *storageManager = [TSStorageManager sharedManager];
     ECKeyPair *identityKeyPair       = [storageManager identityKeyPair];
 
@@ -38,13 +39,15 @@
 
     [[TSNetworkManager sharedManager] makeRequest:request
         success:^(NSURLSessionDataTask *task, id responseObject) {
-          [storageManager storePreKeyRecords:preKeys];
-          [storageManager storeSignedPreKey:signedPreKey.Id signedPreKeyRecord:signedPreKey];
+            DDLogInfo(@"%@ Successfully registered pre keys.", self.tag);
+            [storageManager storePreKeyRecords:preKeys];
+            [storageManager storeSignedPreKey:signedPreKey.Id signedPreKeyRecord:signedPreKey];
 
-          success();
+            success();
         }
         failure:^(NSURLSessionDataTask *task, NSError *error) {
-          failureBlock(error);
+            DDLogError(@"%@ Failed to register pre keys.", self.tag);
+            failureBlock(error);
         }];
 }
 
@@ -121,6 +124,18 @@
     }
 
     return oldRecords;
+}
+
+#pragma mark - Logging
+
++ (NSString *)tag
+{
+    return [NSString stringWithFormat:@"[%@]", self.class];
+}
+
+- (NSString *)tag
+{
+    return self.class.tag;
 }
 
 @end

--- a/src/Messages/OWSDisappearingMessagesFinder.m
+++ b/src/Messages/OWSDisappearingMessagesFinder.m
@@ -214,7 +214,7 @@ static NSString *const OWSDisappearingMessageFinderExpiresAtIndex = @"index_mess
                                                 withName:OWSDisappearingMessageFinderExpiresAtIndex
                                          completionBlock:^(BOOL ready) {
                                              if (ready) {
-                                                 DDLogInfo(@"%@ completed registering extension async.", self.tag);
+                                                 DDLogDebug(@"%@ completed registering extension async.", self.tag);
                                              } else {
                                                  DDLogError(@"%@ failed registering extension async.", self.tag);
                                              }

--- a/src/Storage/TSStorageManager+keyingMaterial.h
+++ b/src/Storage/TSStorageManager+keyingMaterial.h
@@ -35,10 +35,11 @@
  */
 - (NSString *)localNumber;
 + (NSString *)localNumber;
-- (void)runIfHasLocalNumber:(void (^)())block;
+
+- (void)ifLocalNumberPresent:(BOOL)isPresent runAsync:(void (^)())block;
 
 + (void)storeServerToken:(NSString *)authToken signalingKey:(NSString *)signalingKey;
 
-+ (void)storePhoneNumber:(NSString *)phoneNumber;
+- (void)storePhoneNumber:(NSString *)phoneNumber;
 
 @end

--- a/src/TSConstants.h
+++ b/src/TSConstants.h
@@ -40,10 +40,6 @@ typedef enum { kSMSVerification, kPhoneNumberVerification } VerificationTranspor
 #define textSecureDeviceProvisioningAPIFormat @"v1/provisioning/%@"
 #define textSecureDevicesAPIFormat @"v1/devices/%@"
 
-typedef void (^successCompletionBlock)(void);
-typedef void (^failedRegistrationRequestBlock)(void);
-
-
 #pragma mark Push RegistrationSpecific Constants
 typedef NS_ENUM(NSInteger, TSPushRegistrationError) {
     TSPushRegistrationErrorNetwork,

--- a/src/Util/OWSError.h
+++ b/src/Util/OWSError.h
@@ -13,7 +13,8 @@ typedef NS_ENUM(NSInteger, OWSErrorCode) {
     OWSErrorCodePrivacyVerificationFailure = 20,
     OWSErrorCodeUntrustedIdentityKey = 25,
     OWSErrorCodeFailedToSendOutgoingMessage = 30,
-    OWSErrorCodeFailedToDecryptMessage = 100
+    OWSErrorCodeFailedToDecryptMessage = 100,
+    OWSErrorCodeUserError = 2001,
 };
 
 extern NSError *OWSErrorWithCodeDescription(OWSErrorCode code, NSString *description);

--- a/tests/Contacts/SignalRecipientTest.m
+++ b/tests/Contacts/SignalRecipientTest.m
@@ -7,39 +7,41 @@
 
 @interface SignalRecipientTest : XCTestCase
 
+@property (nonatomic) NSString *localNumber;
+
 @end
 
 @implementation SignalRecipientTest
 
-- (void)setUp {
+- (void)setUp
+{
     [super setUp];
-    [TSStorageManager storePhoneNumber:@"+13231231234"];
+    self.localNumber = @"+13231231234";
+    [[TSStorageManager sharedManager] storePhoneNumber:self.localNumber];
 }
 
 - (void)testSelfRecipientWithExistingRecord
 {
     // Sanity Check
-    NSString *localNumber = @"+13231231234";
-    XCTAssertNotNil(localNumber);
-    [[[SignalRecipient alloc] initWithTextSecureIdentifier:localNumber relay:nil supportsVoice:YES] save];
-    XCTAssertNotNil([SignalRecipient recipientWithTextSecureIdentifier:localNumber]);
+    XCTAssertNotNil(self.localNumber);
+    [[[SignalRecipient alloc] initWithTextSecureIdentifier:self.localNumber relay:nil supportsVoice:YES] save];
+    XCTAssertNotNil([SignalRecipient recipientWithTextSecureIdentifier:self.localNumber]);
 
     SignalRecipient *me = [SignalRecipient selfRecipient];
     XCTAssert(me);
-    XCTAssertEqualObjects(localNumber, me.uniqueId);
+    XCTAssertEqualObjects(self.localNumber, me.uniqueId);
 }
 
 - (void)testSelfRecipientWithoutExistingRecord
 {
-    NSString *localNumber = @"+13231231234";
-    XCTAssertNotNil(localNumber);
-    [[SignalRecipient fetchObjectWithUniqueID:localNumber] remove];
+    XCTAssertNotNil(self.localNumber);
+    [[SignalRecipient fetchObjectWithUniqueID:self.localNumber] remove];
     // Sanity Check that there's no existing user.
-    XCTAssertNil([SignalRecipient recipientWithTextSecureIdentifier:localNumber]);
+    XCTAssertNil([SignalRecipient recipientWithTextSecureIdentifier:self.localNumber]);
 
     SignalRecipient *me = [SignalRecipient selfRecipient];
     XCTAssert(me);
-    XCTAssertEqualObjects(localNumber, me.uniqueId);
+    XCTAssertEqualObjects(self.localNumber, me.uniqueId);
 }
 
 @end

--- a/tests/Messages/OWSMessageSenderTest.m
+++ b/tests/Messages/OWSMessageSenderTest.m
@@ -188,7 +188,7 @@ NS_ASSUME_NONNULL_BEGIN
     [super setUp];
 
     // Hack to make sure we don't explode when sending sync message.
-    [TSStorageManager storePhoneNumber:@"+13231231234"];
+    [[TSStorageManager sharedManager] storePhoneNumber:@"+13231231234"];
 
     self.thread = [[TSContactThread alloc] initWithUniqueId:@"fake-thread-id"];
     [self.thread save];


### PR DESCRIPTION
- Separate account registration from push token registration
- Provide better errors when validation fails (e.g. numbers don't match, numbers blank)
- More logging during registration
- Call success after setting phone number to avoid any future race condition
  
  This isn't currently causing problems, but it's unexpected that we'd
  mutate the state _after_ calling a callback which might inuitively rely
  on that state.
- Don't throw exception off thread when device keys 404's
- Better async startup handling
  - move processing off main thread
  - reduce code duplicattion
  - don't wrap it in a transaction in the future case where we want to
    further access the DB

// FREEBIE
