### PR TITLE
EndSessionMessage notifies remote side of reset session

### DIFF
--- a/SignalServiceKit.podspec
+++ b/SignalServiceKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SignalServiceKit"
-  s.version          = "0.4.0"
+  s.version          = "0.5.0"
   s.summary          = "An Objective-C library for communicating with the Signal messaging service."
 
   s.description      = <<-DESC

--- a/src/Messages/Interactions/OWSEndSessionMessage.h
+++ b/src/Messages/Interactions/OWSEndSessionMessage.h
@@ -1,0 +1,13 @@
+//  Created by Michael Kirk on 11/3/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "TSOutgoingMessage.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(EndSessionMessage)
+@interface OWSEndSessionMessage : TSOutgoingMessage
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/Interactions/OWSEndSessionMessage.m
+++ b/src/Messages/Interactions/OWSEndSessionMessage.m
@@ -1,0 +1,28 @@
+//  Created by Michael Kirk on 11/3/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSEndSessionMessage.h"
+#import "OWSSignalServiceProtos.pb.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSEndSessionMessage
+
+- (void)saveWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
+{
+    // override superclass with no-op.
+    //
+    // There's no need to save this message, since it's not displayed to the user.
+}
+
+- (OWSSignalServiceProtosDataMessageBuilder *)dataMessageBuilder
+{
+    OWSSignalServiceProtosDataMessageBuilder *builder = [super dataMessageBuilder];
+    [builder setFlags:OWSSignalServiceProtosDataMessageFlagsEndSession];
+
+    return builder;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSMessageSender.h
+++ b/src/Messages/OWSMessageSender.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class TSThread;
 @protocol ContactsManagerProtocol;
 
+NS_SWIFT_NAME(MessageSender)
 @interface OWSMessageSender : NSObject {
 
 @protected

--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -300,6 +300,10 @@ NSString *const OWSMessageSenderInvalidDeviceException = @"InvalidDeviceExceptio
                      attempts:OWSMessageSenderRetryAttempts
                       success:successHandler
                       failure:failureHandler];
+        } else {
+            DDLogError(@"%@ Unexpected unhandlable message: %@", self.tag, message);
+            NSError *error = OWSErrorMakeFailedToSendOutgoingMessageError();
+            failureHandler(error);
         }
     });
 }


### PR DESCRIPTION
Otherwise they'll send us messages we can't decrypt.

Also: Log and fail when message doesn't send due to no thread being specified.

// FREEBIE