### PR TITLE
Only fetch PreKey once.

### DIFF
--- a/SignalServiceKit.podspec
+++ b/SignalServiceKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SignalServiceKit"
-  s.version          = "0.5.1"
+  s.version          = "0.5.2"
   s.summary          = "An Objective-C library for communicating with the Signal messaging service."
 
   s.description      = <<-DESC

--- a/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.h
+++ b/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.h
@@ -22,8 +22,7 @@ extern NSString *TSInvalidRecipientKey;
 + (instancetype)untrustedKeyWithOutgoingMessage:(TSOutgoingMessage *)outgoingMessage
                                        inThread:(TSThread *)thread
                                    forRecipient:(NSString *)recipientId
-                                   preKeyBundle:(PreKeyBundle *)preKeyBundle
-                                withTransaction:(YapDatabaseReadWriteTransaction *)transaction;
+                                   preKeyBundle:(PreKeyBundle *)preKeyBundle;
 
 @property (nonatomic, readonly) NSString *recipientId;
 @property (nonatomic, readonly) NSString *messageId;

--- a/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.m
+++ b/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.m
@@ -28,7 +28,7 @@ NSString *TSInvalidRecipientKey = @"TSInvalidRecipientKey";
                                inThread:(TSThread *)thread
                            forRecipient:(NSString *)recipientId
                            preKeyBundle:(PreKeyBundle *)preKeyBundle
-                            transaction:(YapDatabaseReadWriteTransaction *)transaction {
+{
     self = [super initWithTimestamp:message.timestamp
                            inThread:thread
                   failedMessageType:TSErrorMessageWrongTrustedIdentityKey];
@@ -46,12 +46,11 @@ NSString *TSInvalidRecipientKey = @"TSInvalidRecipientKey";
                                        inThread:(TSThread *)thread
                                    forRecipient:(NSString *)recipientId
                                    preKeyBundle:(PreKeyBundle *)preKeyBundle
-                                withTransaction:(YapDatabaseReadWriteTransaction *)transaction {
+{
     TSInvalidIdentityKeySendingErrorMessage *message = [[self alloc] initWithOutgoingMessage:outgoingMessage
                                                                                     inThread:thread
                                                                                 forRecipient:recipientId
-                                                                                preKeyBundle:preKeyBundle
-                                                                                 transaction:transaction];
+                                                                                preKeyBundle:preKeyBundle];
     return message;
 }
 


### PR DESCRIPTION
Previously we were retrying as if it might succeed, and running into
rate-limit errors.

Also, added a specific rate limit error message.

// FREEBIE