### PR TITLE
Rename an OWSContactsManager method

### DIFF
--- a/src/Contacts/Threads/TSContactThread.m
+++ b/src/Contacts/Threads/TSContactThread.m
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)name
 {
-    return [[TextSecureKitEnv sharedEnv].contactsManager nameStringForPhoneIdentifier:self.contactIdentifier];
+    return [[TextSecureKitEnv sharedEnv].contactsManager displayNameForPhoneIdentifier:self.contactIdentifier];
 }
 
 #if TARGET_OS_IPHONE

--- a/src/Messages/OWSDisappearingMessagesJob.m
+++ b/src/Messages/OWSDisappearingMessagesJob.m
@@ -192,7 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     if ([message isKindOfClass:[TSIncomingMessage class]]) {
         TSIncomingMessage *incomingMessage = (TSIncomingMessage *)message;
-        NSString *contactName = [contactsManager nameStringForPhoneIdentifier:incomingMessage.authorId];
+        NSString *contactName = [contactsManager displayNameForPhoneIdentifier:incomingMessage.authorId];
 
         [[[OWSDisappearingConfigurationUpdateInfoMessage alloc] initWithTimestamp:message.timestamp
                                                                            thread:message.thread

--- a/src/Messages/TSGroupModel.m
+++ b/src/Messages/TSGroupModel.m
@@ -81,7 +81,7 @@
 
     if ([membersWhoLeft count] > 0) {
         NSArray *oldMembersNames = [[membersWhoLeft allObjects] map:^NSString*(NSString* item) {
-            return [contactsManager nameStringForPhoneIdentifier:item];
+            return [contactsManager displayNameForPhoneIdentifier:item];
         }];
         updatedGroupInfoString = [updatedGroupInfoString
                                   stringByAppendingString:[NSString
@@ -91,7 +91,7 @@
     
     if ([membersWhoJoined count] > 0) {
         NSArray *newMembersNames = [[membersWhoJoined allObjects] map:^NSString*(NSString* item) {
-            return [contactsManager nameStringForPhoneIdentifier:item];
+            return [contactsManager displayNameForPhoneIdentifier:item];
         }];
         updatedGroupInfoString = [updatedGroupInfoString
                                   stringByAppendingString:[NSString stringWithFormat:NSLocalizedString(@"GROUP_MEMBER_JOINED", @""),

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -453,7 +453,7 @@ NS_ASSUME_NONNULL_BEGIN
              durationSeconds:OWSDisappearingMessagesConfigurationDefaultExpirationDuration];
     }
     [disappearingMessagesConfiguration save];
-    NSString *name = [self.contactsManager nameStringForPhoneIdentifier:envelope.source];
+    NSString *name = [self.contactsManager displayNameForPhoneIdentifier:envelope.source];
     OWSDisappearingConfigurationUpdateInfoMessage *message =
         [[OWSDisappearingConfigurationUpdateInfoMessage alloc] initWithTimestamp:envelope.timestamp
                                                                           thread:thread
@@ -502,7 +502,7 @@ NS_ASSUME_NONNULL_BEGIN
                   break;
               }
               case OWSSignalServiceProtosGroupContextTypeQuit: {
-                  NSString *nameString = [self.contactsManager nameStringForPhoneIdentifier:envelope.source];
+                  NSString *nameString = [self.contactsManager displayNameForPhoneIdentifier:envelope.source];
 
                   NSString *updateGroupInfo =
                       [NSString stringWithFormat:NSLocalizedString(@"GROUP_MEMBER_LEFT", @""), nameString];

--- a/src/Protocols/ContactsManagerProtocol.h
+++ b/src/Protocols/ContactsManagerProtocol.h
@@ -7,7 +7,7 @@
 
 @protocol ContactsManagerProtocol <NSObject>
 
-- (NSString *)nameStringForPhoneIdentifier:(NSString *)phoneNumber;
+- (NSString * _Nonnull)displayNameForPhoneIdentifier:(NSString *)phoneNumber;
 - (NSArray<Contact *> *)signalContacts;
 + (BOOL)name:(NSString *)nameString matchesQuery:(NSString *)queryString;
 

--- a/src/Protocols/ContactsManagerProtocol.h
+++ b/src/Protocols/ContactsManagerProtocol.h
@@ -7,12 +7,12 @@
 
 @protocol ContactsManagerProtocol <NSObject>
 
-- (NSString * _Nonnull)displayNameForPhoneIdentifier:(NSString *)phoneNumber;
-- (NSArray<Contact *> *)signalContacts;
-+ (BOOL)name:(NSString *)nameString matchesQuery:(NSString *)queryString;
+- (NSString * _Nonnull)displayNameForPhoneIdentifier:(NSString * _Nullable)phoneNumber;
+- (NSArray<Contact *> * _Nonnull)signalContacts;
++ (BOOL)name:(NSString * _Nonnull)nameString matchesQuery:(NSString * _Nonnull)queryString;
 
 #if TARGET_OS_IPHONE
-- (UIImage *)imageForPhoneIdentifier:(NSString *)phoneNumber;
+- (UIImage * _Nullable)imageForPhoneIdentifier:(NSString * _Nullable)phoneNumber;
 #endif
 
 @end

--- a/src/Security/OWSFingerprintBuilder.m
+++ b/src/Security/OWSFingerprintBuilder.m
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (OWSFingerprint *)fingerprintWithTheirSignalId:(NSString *)theirSignalId theirIdentityKey:(NSData *)theirIdentityKey
 {
-    NSString *theirName = [self.contactsManager nameStringForPhoneIdentifier:theirSignalId];
+    NSString *theirName = [self.contactsManager displayNameForPhoneIdentifier:theirSignalId];
 
     NSString *mySignalId = [self.storageManager localNumber];
     NSData *myIdentityKey = [self.storageManager identityKeyPair].publicKey;

--- a/tests/TestSupport/Fakes/OWSFakeContactsManager.m
+++ b/tests/TestSupport/Fakes/OWSFakeContactsManager.m
@@ -9,22 +9,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OWSFakeContactsManager
 
-- (NSString *)nameStringForPhoneIdentifier:(NSString *)phoneNumber
+- (NSString * _Nonnull)displayNameForPhoneIdentifier:(NSString * _Nullable)phoneNumber
 {
     return @"Fake name";
 }
 
-- (NSArray<Contact *> *)signalContacts
+- (NSArray<Contact *> * _Nonnull)signalContacts
 {
     return @[];
 }
 
-+ (BOOL)name:(NSString *)nameString matchesQuery:(NSString *)queryString
++ (BOOL)name:(NSString * _Nonnull)nameString matchesQuery:(NSString * _Nonnull)queryString
 {
     return YES;
 }
 
-- (nullable UIImage *)imageForPhoneIdentifier:(NSString *)phoneNumber
+- (UIImage * _Nullable)imageForPhoneIdentifier:(NSString * _Nullable)phoneNumber
 {
     return nil;
 }


### PR DESCRIPTION
Method renames to correspond to work done for [Signal-iOS Issue #1512](https://github.com/WhisperSystems/Signal-iOS/issues/1512). Also includes cleanups to resolve a few nullability warnings.

Please feel free to cherry-pick or squash as you see fit.