### PR TITLE
Allow signal database to be in a shared folder

### DIFF
--- a/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		B6273DE11C13A2E500738558 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B6273DE01C13A2E500738558 /* Assets.xcassets */; };
 		B6273DE41C13A2E500738558 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6273DE21C13A2E500738558 /* LaunchScreen.storyboard */; };
 		D2AECE731DE8C3360068CE15 /* ContactSortingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D2AECE721DE8C3360068CE15 /* ContactSortingTest.m */; };
+		E99F3D091DF8731100801A1C /* Debug.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = E99F3D081DF872ED00801A1C /* Debug.entitlements */; };
+		E99F3D0A1DF873D000801A1C /* TSKitiOSTestApp.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = E9944E691DF8599600DB2657 /* TSKitiOSTestApp.entitlements */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,6 +110,8 @@
 		C0DC1A83C39CBC09FB2405A3 /* libPods-TSKitiOSTestAppTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TSKitiOSTestAppTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2AECE721DE8C3360068CE15 /* ContactSortingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ContactSortingTest.m; path = ../../../tests/Contacts/ContactSortingTest.m; sourceTree = "<group>"; };
 		D3737F7A041D7147015C02C2 /* Pods-TSKitiOSTestAppTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TSKitiOSTestAppTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TSKitiOSTestAppTests/Pods-TSKitiOSTestAppTests.release.xcconfig"; sourceTree = "<group>"; };
+		E9944E691DF8599600DB2657 /* TSKitiOSTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TSKitiOSTestApp.entitlements; sourceTree = "<group>"; };
+		E99F3D081DF872ED00801A1C /* Debug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Debug.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -288,6 +292,8 @@
 		B6273DD31C13A2E500738558 /* TSKitiOSTestApp */ = {
 			isa = PBXGroup;
 			children = (
+				E99F3D081DF872ED00801A1C /* Debug.entitlements */,
+				E9944E691DF8599600DB2657 /* TSKitiOSTestApp.entitlements */,
 				B6273DD71C13A2E500738558 /* AppDelegate.h */,
 				B6273DD81C13A2E500738558 /* AppDelegate.m */,
 				B6273DDA1C13A2E500738558 /* ViewController.h */,
@@ -383,6 +389,11 @@
 					B6273DD01C13A2E500738558 = {
 						CreatedOnToolsVersion = 7.1.1;
 						DevelopmentTeam = U68MSDN6DR;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+						};
 					};
 					B6273DE91C13A2E500738558 = {
 						CreatedOnToolsVersion = 7.1.1;
@@ -415,6 +426,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E99F3D0A1DF873D000801A1C /* TSKitiOSTestApp.entitlements in Resources */,
+				E99F3D091DF8731100801A1C /* Debug.entitlements in Resources */,
 				B6273DE41C13A2E500738558 /* LaunchScreen.storyboard in Resources */,
 				B6273DE11C13A2E500738558 /* Assets.xcassets in Resources */,
 				B6273DDF1C13A2E500738558 /* Main.storyboard in Resources */,
@@ -688,6 +701,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = U68MSDN6DR;
+				CODE_SIGN_ENTITLEMENTS = TSKitiOSTestApp/Debug.entitlements;
 				INFOPLIST_FILE = TSKitiOSTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.whispersystems.TSKitiOSTestApp;
@@ -701,6 +715,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = U68MSDN6DR;
+				CODE_SIGN_ENTITLEMENTS = TSKitiOSTestApp/TSKitiOSTestApp.entitlements;
 				INFOPLIST_FILE = TSKitiOSTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.whispersystems.TSKitiOSTestApp;

--- a/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		D2AECE731DE8C3360068CE15 /* ContactSortingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D2AECE721DE8C3360068CE15 /* ContactSortingTest.m */; };
 		E99F3D091DF8731100801A1C /* Debug.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = E99F3D081DF872ED00801A1C /* Debug.entitlements */; };
 		E99F3D0A1DF873D000801A1C /* TSKitiOSTestApp.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = E9944E691DF8599600DB2657 /* TSKitiOSTestApp.entitlements */; };
+		E99F3D0E1DF8A63000801A1C /* TSStorageManagerMigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E99F3D0D1DF8A63000801A1C /* TSStorageManagerMigrationTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -112,6 +113,7 @@
 		D3737F7A041D7147015C02C2 /* Pods-TSKitiOSTestAppTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TSKitiOSTestAppTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TSKitiOSTestAppTests/Pods-TSKitiOSTestAppTests.release.xcconfig"; sourceTree = "<group>"; };
 		E9944E691DF8599600DB2657 /* TSKitiOSTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TSKitiOSTestApp.entitlements; sourceTree = "<group>"; };
 		E99F3D081DF872ED00801A1C /* Debug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Debug.entitlements; sourceTree = "<group>"; };
+		E99F3D0D1DF8A63000801A1C /* TSStorageManagerMigrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSStorageManagerMigrationTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -178,6 +180,7 @@
 			isa = PBXGroup;
 			children = (
 				45458B6E1CC342B600A02153 /* TSMessageStorageTests.m */,
+				E99F3D0D1DF8A63000801A1C /* TSStorageManagerMigrationTests.m */,
 				45458B6F1CC342B600A02153 /* TSStorageIdentityKeyStoreTests.m */,
 				45458B701CC342B600A02153 /* TSStoragePreKeyStoreTests.m */,
 				45458B711CC342B600A02153 /* TSStorageSignedPreKeyStore.m */,
@@ -567,6 +570,7 @@
 				453E1FCF1DA8313100DDD7B7 /* OWSMessageSenderTest.m in Sources */,
 				459850C11D22C6F2006FFEDB /* PhoneNumberTest.m in Sources */,
 				45458B7A1CC342B600A02153 /* TSStorageSignedPreKeyStore.m in Sources */,
+				E99F3D0E1DF8A63000801A1C /* TSStorageManagerMigrationTests.m in Sources */,
 				453E1FDB1DA83EFB00DDD7B7 /* OWSFakeContactsUpdater.m in Sources */,
 				D2AECE731DE8C3360068CE15 /* ContactSortingTest.m in Sources */,
 				453E1FD81DA83E1000DDD7B7 /* OWSFakeContactsManager.m in Sources */,

--- a/Example/TSKitiOSTestApp/TSKitiOSTestApp/Debug.entitlements
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestApp/Debug.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.fr.guillet.test.signal_service</string>
+	</array>
+</dict>
+</plist>

--- a/Example/TSKitiOSTestApp/TSKitiOSTestApp/TSKitiOSTestApp.entitlements
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestApp/TSKitiOSTestApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.fr.guillet.test.signal_service</string>
+	</array>
+</dict>
+</plist>

--- a/src/Storage/TSStorageManager+databaseLocation.h
+++ b/src/Storage/TSStorageManager+databaseLocation.h
@@ -35,4 +35,6 @@
 
 + (NSString *)getDbPath;
 
++ (void) migrateStandaloneDb;
+
 @end

--- a/src/Storage/TSStorageManager+databaseLocation.h
+++ b/src/Storage/TSStorageManager+databaseLocation.h
@@ -18,6 +18,14 @@
 + (NSString *)standaloneDbPath:(NSFileManager *)fileManager;
 
 /**
+ *  Full path of the signal database when used as part of an App Group
+ *
+ *  @return database path
+ */
+
++ (NSString *)sharedDbPath:(NSFileManager *)fileManager;
+
+/**
  *  Rely on the project configuration to return the appropriate database path
  *
  *  @return database path

--- a/src/Storage/TSStorageManager+databaseLocation.h
+++ b/src/Storage/TSStorageManager+databaseLocation.h
@@ -1,0 +1,30 @@
+//
+//  TSStorageManager+databaseLocation.h
+//
+//  Created by Thomass Guillet on 07/12/16.
+//  Copyright (c) 2016 Open Whisper Systems. All rights reserved.
+//
+
+#import "TSStorageManager.h"
+
+@interface TSStorageManager (databaseLocation)
+
+/**
+ *  Full path of the signal database when used alone
+ *
+ *  @return database path
+ */
+
++ (NSString *)standaloneDbPath:(NSFileManager *)fileManager;
+
+/**
+ *  Rely on the project configuration to return the appropriate database path
+ *
+ *  @return database path
+ */
+
++ (NSString *)determineiOSDbPath:(NSFileManager *)fileManager;
+
++ (NSString *)getDbPath;
+
+@end

--- a/src/Storage/TSStorageManager+databaseLocation.m
+++ b/src/Storage/TSStorageManager+databaseLocation.m
@@ -1,0 +1,47 @@
+//
+//  TSStorageManager+databaseLocation.m
+//
+//  Created by Thomass Guillet on 07/12/16.
+//  Copyright (c) 2016 Open Whisper Systems. All rights reserved.
+//
+
+#import "TSStorageManager+databaseLocation.h"
+
+static const NSString *const databaseName = @"Signal.sqlite";
+
+@implementation TSStorageManager (databaseLocation)
+
++ (NSString *)standaloneDbPath:(NSFileManager *)fileManager {
+    NSURL *fileURL = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+    NSString *path = [fileURL path];
+
+    return [path stringByAppendingFormat:@"/%@", databaseName];
+}
+
++ (NSString *)determineiOSDbPath:(NSFileManager *)fileManager {
+    return [self standaloneDbPath:fileManager];
+}
+
++ (NSString *)getDbPath {
+    NSString *databasePath;
+
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+#if TARGET_OS_IPHONE
+    databasePath = [TSStorageManager determineiOSDbPath:fileManager];
+#elif TARGET_OS_MAC
+
+    NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
+    NSArray *urlPaths  = [fileManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask];
+
+    NSURL *appDirectory = [[urlPaths objectAtIndex:0] URLByAppendingPathComponent:bundleID isDirectory:YES];
+
+    if (![fileManager fileExistsAtPath:[appDirectory path]]) {
+        [fileManager createDirectoryAtURL:appDirectory withIntermediateDirectories:NO attributes:nil error:nil];
+    }
+
+    databasePath = [appDirectory.filePathURL.absoluteString stringByAppendingFormat:@"/%@", databaseName];
+#endif
+
+    return databasePath;
+}
+@end

--- a/src/Storage/TSStorageManager.m
+++ b/src/Storage/TSStorageManager.m
@@ -151,9 +151,10 @@ static NSString *keychainDBPassAccount    = @"TSDatabasePass";
 
 - (void)protectSignalFiles {
     [self protectFolderAtPath:[TSAttachmentStream attachmentsFolder]];
-    [self protectFolderAtPath:[self dbPath]];
-    [self protectFolderAtPath:[[self dbPath] stringByAppendingString:@"-shm"]];
-    [self protectFolderAtPath:[[self dbPath] stringByAppendingString:@"-wal"]];
+    NSString *dbPath = [self dbPath];
+    [self protectFolderAtPath:dbPath];
+    [self protectFolderAtPath:[dbPath stringByAppendingString:@"-shm"]];
+    [self protectFolderAtPath:[dbPath stringByAppendingString:@"-wal"]];
 }
 
 - (void)protectFolderAtPath:(NSString *)path {

--- a/src/Storage/TSStorageManager.m
+++ b/src/Storage/TSStorageManager.m
@@ -2,6 +2,7 @@
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
 
 #import "TSStorageManager.h"
+#import "TSStorageManager+databaseLocation.h"
 #import "NSData+Base64.h"
 #import "OWSDisappearingMessagesFinder.h"
 #import "OWSReadReceipt.h"
@@ -18,7 +19,6 @@
 
 NSString *const TSUIDatabaseConnectionDidUpdateNotification = @"TSUIDatabaseConnectionDidUpdateNotification";
 
-static const NSString *const databaseName = @"Signal.sqlite";
 static NSString *keychainService          = @"TSKeyChainService";
 static NSString *keychainDBPassAccount    = @"TSDatabasePass";
 
@@ -194,28 +194,7 @@ static NSString *keychainDBPassAccount    = @"TSDatabasePass";
 }
 
 - (NSString *)dbPath {
-    NSString *databasePath;
-
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-#if TARGET_OS_IPHONE
-    NSURL *fileURL = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
-    NSString *path = [fileURL path];
-    databasePath   = [path stringByAppendingFormat:@"/%@", databaseName];
-#elif TARGET_OS_MAC
-
-    NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
-    NSArray *urlPaths  = [fileManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask];
-
-    NSURL *appDirectory = [[urlPaths objectAtIndex:0] URLByAppendingPathComponent:bundleID isDirectory:YES];
-
-    if (![fileManager fileExistsAtPath:[appDirectory path]]) {
-        [fileManager createDirectoryAtURL:appDirectory withIntermediateDirectories:NO attributes:nil error:nil];
-    }
-
-    databasePath = [appDirectory.filePathURL.absoluteString stringByAppendingFormat:@"/%@", databaseName];
-#endif
-
-    return databasePath;
+    return [TSStorageManager getDbPath];
 }
 
 - (BOOL)databasePasswordAccessible

--- a/tests/Storage/TSStorageManagerMigrationTests.m
+++ b/tests/Storage/TSStorageManagerMigrationTests.m
@@ -1,0 +1,56 @@
+//
+//  TSStorageManagerMigrationTests.m
+//
+//  Created by Thomas Guillet on 07/12/2016.
+//  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "Cryptography.h"
+#import "TSThread.h"
+#import "TSContactThread.h"
+#import "TSGroupThread.h"
+
+#import "TSStorageManager.h"
+
+#import "TSIncomingMessage.h"
+#import "TSMessage.h"
+#import "TSOutgoingMessage.h"
+#import "TSStorageManager+databaseLocation.h"
+
+
+@interface TSStorageManagerMigrationTests : XCTestCase
+
+@property TSContactThread *thread;
+
+@end
+
+@implementation TSStorageManagerMigrationTests
+
+- (void)testStuff
+{
+    NSString *collection = @"collection";
+    NSString *key = @"key";
+    NSString *value = @"value";
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+
+    NSString *standalonePath = [TSStorageManager standaloneDbPath:fileManager];
+    YapDatabase *database = [[YapDatabase alloc] initWithPath:standalonePath];
+    YapDatabaseConnection *connection = database.newConnection;
+
+    [connection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        [transaction setObject:value forKey:key inCollection:collection];
+    }];
+
+    [TSStorageManager migrateStandaloneDb];
+    NSString *sharedPath = [TSStorageManager sharedDbPath:fileManager];
+    NSString *dbPath = [[TSStorageManager sharedManager].database databasePath];
+    XCTAssert([dbPath isEqualToString:sharedPath]);
+    [[TSStorageManager sharedManager].newDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        NSString *returnedValue = [transaction objectForKey:key inCollection:collection];
+        XCTAssert([returnedValue isEqualToString:value]);
+    }];
+}
+
+@end


### PR DESCRIPTION
This is a first formal attempt to allow signal database to be in a shared folder.

A shared location exists if the application is part of a group with the suffix "signal_service".
If there is no such group, the database is placed in a standalone location (current location).

I added some logic to allow App Group retrieval from different entitlement files to facilitate contributor work.

Note: App group names will have to be updated to group names *owned* by the proper development team (OWS).

I am more than happy to refactor/amend that code.