### PR TITLE
Remove convoluted dependency of PhoneNumberUtil to ContactsManagerProtocol

### DIFF
--- a/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		B6273DE11C13A2E500738558 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B6273DE01C13A2E500738558 /* Assets.xcassets */; };
 		B6273DE41C13A2E500738558 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6273DE21C13A2E500738558 /* LaunchScreen.storyboard */; };
 		D2AECE731DE8C3360068CE15 /* ContactSortingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D2AECE721DE8C3360068CE15 /* ContactSortingTest.m */; };
+		E95668321E0964F9002418B1 /* PhoneNumberUtilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E95668311E0964F9002418B1 /* PhoneNumberUtilTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,6 +109,7 @@
 		C0DC1A83C39CBC09FB2405A3 /* libPods-TSKitiOSTestAppTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TSKitiOSTestAppTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2AECE721DE8C3360068CE15 /* ContactSortingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ContactSortingTest.m; path = ../../../tests/Contacts/ContactSortingTest.m; sourceTree = "<group>"; };
 		D3737F7A041D7147015C02C2 /* Pods-TSKitiOSTestAppTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TSKitiOSTestAppTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TSKitiOSTestAppTests/Pods-TSKitiOSTestAppTests.release.xcconfig"; sourceTree = "<group>"; };
+		E95668311E0964F9002418B1 /* PhoneNumberUtilTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PhoneNumberUtilTest.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,6 +188,7 @@
 		45458B721CC342B600A02153 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				E95668311E0964F9002418B1 /* PhoneNumberUtilTest.m */,
 				45458B731CC342B600A02153 /* CryptographyTests.m */,
 				45458B741CC342B600A02153 /* MessagePaddingTests.m */,
 			);
@@ -561,6 +564,7 @@
 				4516E3EA1DD1542300DC4206 /* TSContactThreadTest.m in Sources */,
 				45458B771CC342B600A02153 /* TSMessageStorageTests.m in Sources */,
 				45046FE01D95A6130015EFF2 /* TSMessagesManagerTest.m in Sources */,
+				E95668321E0964F9002418B1 /* PhoneNumberUtilTest.m in Sources */,
 				45458B7C1CC342B600A02153 /* MessagePaddingTests.m in Sources */,
 				45A856AC1D220BFF0056CD4D /* TSAttributesTest.m in Sources */,
 				45731A6C1DA87AA1007E22AA /* TSOutgoingMessageTest.m in Sources */,

--- a/src/Contacts/PhoneNumberUtil.h
+++ b/src/Contacts/PhoneNumberUtil.h
@@ -6,6 +6,8 @@
 
 @property (nonatomic, retain) NBPhoneNumberUtil *nbPhoneNumberUtil;
 
++ (BOOL)name:(NSString *)nameString matchesQuery:(NSString *)queryString;
+
 + (NSString *)callingCodeFromCountryCode:(NSString *)code;
 + (NSString *)countryNameFromCountryCode:(NSString *)code;
 + (NSArray *)countryCodesForSearchTerm:(NSString *)searchTerm;

--- a/src/Contacts/PhoneNumberUtil.m
+++ b/src/Contacts/PhoneNumberUtil.m
@@ -1,7 +1,6 @@
 #import "Constraints.h"
 #import "FunctionalUtil.h"
 #import "PhoneNumberUtil.h"
-#import "TextSecureKitEnv.h"
 #import "Util.h"
 
 @implementation PhoneNumberUtil
@@ -39,6 +38,21 @@
     return [NSString stringWithFormat:@"%@%@", COUNTRY_CODE_PREFIX, callingCode];
 }
 
++ (BOOL)name:(NSString *)nameString matchesQuery:(NSString *)queryString {
+    NSCharacterSet *whitespaceSet = NSCharacterSet.whitespaceCharacterSet;
+    NSArray *queryStrings         = [queryString componentsSeparatedByCharactersInSet:whitespaceSet];
+    NSArray *nameStrings          = [nameString componentsSeparatedByCharactersInSet:whitespaceSet];
+
+    return [queryStrings all:^int(NSString *query) {
+        if (query.length == 0)
+            return YES;
+        return [nameStrings any:^int(NSString *nameWord) {
+            NSStringCompareOptions searchOpts = NSCaseInsensitiveSearch | NSAnchoredSearch;
+            return [nameWord rangeOfString:query options:searchOpts].location != NSNotFound;
+        }];
+    }];
+}
+
 // search term -> country codes
 + (NSArray *)countryCodesForSearchTerm:(NSString *)searchTerm {
     NSArray *countryCodes = NSLocale.ISOCountryCodes;
@@ -48,7 +62,7 @@
           NSString *countryName = [self countryNameFromCountryCode:code];
           NSString *callingCode = [self callingCodeFromCountryCode:code];
 
-          if ([[[TextSecureKitEnv sharedEnv].contactsManager class] name:countryName matchesQuery:searchTerm]) {
+          if ([self name:countryName matchesQuery:searchTerm]) {
               return YES;
           }
 

--- a/src/Protocols/ContactsManagerProtocol.h
+++ b/src/Protocols/ContactsManagerProtocol.h
@@ -9,7 +9,6 @@
 
 - (NSString * _Nonnull)displayNameForPhoneIdentifier:(NSString * _Nullable)phoneNumber;
 - (NSArray<Contact *> * _Nonnull)signalContacts;
-+ (BOOL)name:(NSString * _Nonnull)nameString matchesQuery:(NSString * _Nonnull)queryString;
 
 #if TARGET_OS_IPHONE
 - (UIImage * _Nullable)imageForPhoneIdentifier:(NSString * _Nullable)phoneNumber;

--- a/tests/Util/PhoneNumberUtilTest.m
+++ b/tests/Util/PhoneNumberUtilTest.m
@@ -1,0 +1,36 @@
+//
+//  PhoneNumberTest.m
+//  Signal
+//
+//  Created by Michael Kirk on 6/28/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "PhoneNumberUtil.h"
+
+@interface PhoneNumberUtilTest : XCTestCase
+
+@end
+
+@implementation PhoneNumberUtilTest
+
+- (void)testQueryMatching {
+    XCTAssertTrue([PhoneNumberUtil name:@"big dave" matchesQuery:@"big dave"]);
+    XCTAssertTrue([PhoneNumberUtil name:@"big dave" matchesQuery:@"dave big"]);
+    XCTAssertTrue([PhoneNumberUtil name:@"big dave" matchesQuery:@"dave"]);
+    XCTAssertTrue([PhoneNumberUtil name:@"big dave" matchesQuery:@"big"]);
+    XCTAssertTrue([PhoneNumberUtil name:@"big dave" matchesQuery:@"big "]);
+    XCTAssertTrue([PhoneNumberUtil name:@"big dave" matchesQuery:@"      big       "]);
+    XCTAssertTrue([PhoneNumberUtil name:@"big dave" matchesQuery:@"dav"]);
+    XCTAssertTrue([PhoneNumberUtil name:@"big dave" matchesQuery:@"bi dav"]);
+    XCTAssertTrue([PhoneNumberUtil name:@"big dave" matchesQuery:@"big big big big big big big big big big dave dave dave dave dave"]);
+    
+    XCTAssertFalse([PhoneNumberUtil name:@"big dave" matchesQuery:@"ave"]);
+    XCTAssertFalse([PhoneNumberUtil name:@"big dave" matchesQuery:@"dare"]);
+    XCTAssertFalse([PhoneNumberUtil name:@"big dave" matchesQuery:@"mike"]);
+    XCTAssertFalse([PhoneNumberUtil name:@"big dave" matchesQuery:@"mike"]);
+    XCTAssertFalse([PhoneNumberUtil name:@"dave" matchesQuery:@"big"]);
+}
+
+@end


### PR DESCRIPTION
For legacy reason, I guess, PhoneNumberUtil depends on ContactsManagerProtocol to match country names to specific terms during a search.

I had a look in Signal-iOS repository and there are no other consumer of ```name:matchesQuery:```.

As is (and outside of Signal),  PhoneNumberUtil throw an error in ```countryCodesForSearchTerm:```when something else then ```nil``` is provided.

The commit fixes that.
I also moved the tests from Signal here (cf. PhoneNumberUtilTest.m)