### PR TITLE
Charlesmchen/censorship circumvention 2

### DIFF
--- a/src/Network/OWSCensorshipConfiguration.h
+++ b/src/Network/OWSCensorshipConfiguration.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OWSCensorshipConfiguration : NSObject
 
-- (NSString *)frontingHost;
+- (NSString *)frontingHost:(NSString *)e164PhonNumber;
 - (NSString *)reflectorHost;
 - (BOOL)isCensoredPhoneNumber:(NSString *)e164PhonNumber;
 

--- a/src/Network/OWSCensorshipConfiguration.m
+++ b/src/Network/OWSCensorshipConfiguration.m
@@ -24,10 +24,18 @@ NSString *const OWSCensorshipConfigurationReflectorHost = @"signal-reflector-mee
 - (NSArray<NSString *> *)censoredCountryCodes
 {
     // Reports of censorship in:
-    // Egypt
-    // UAE
-    return @[@"+20",
-             @"+971"];
+    return @[
+             // Egypt
+             @"+20",
+             // Cuba
+             @"+53",
+             // Oman
+             @"+968",
+             // UAE
+             @"+971",
+             // Iran
+             @"+98",
+             ];
 }
 
 - (BOOL)isCensoredPhoneNumber:(NSString *)e164PhonNumber

--- a/src/Network/OWSCensorshipConfiguration.m
+++ b/src/Network/OWSCensorshipConfiguration.m
@@ -50,7 +50,7 @@ NSString *const OWSCensorshipConfigurationReflectorHost = @"signal-reflector-mee
              // Oman
              @"+968": @"google.com.om",
              // UAE
-             @"+971": @"google.com.ae",
+             @"+971": @"google.ae",
              // Iran
              //
              // There does not appear to be a specific Google domain for Iran.

--- a/src/Network/OWSCensorshipConfiguration.m
+++ b/src/Network/OWSCensorshipConfiguration.m
@@ -3,6 +3,7 @@
 
 #import "OWSCensorshipConfiguration.h"
 #import "TSStorageManager.h"
+#import "Asserts.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -15,7 +16,7 @@ NSString *const OWSCensorshipConfigurationReflectorHost = @"signal-reflector-mee
     OWSAssert(e164PhonNumber.length > 0);
     
     NSString *domain = nil;
-    for (NSString *countryCode in self.censoredCountryCodes.allKeys) {
+    for (NSString *countryCode in self.censoredCountryCodes) {
         if ([e164PhonNumber hasPrefix:countryCode]) {
             domain = self.censoredCountryCodes[countryCode];
         }
@@ -38,10 +39,17 @@ NSString *const OWSCensorshipConfigurationReflectorHost = @"signal-reflector-mee
 
 - (NSDictionary<NSString *, NSString *> *)censoredCountryCodes
 {
-    // Domain fronting should be used for the following countries.
+    // The set of countries for which domain fronting should be used.
     //
-    // For each country, we should the appropriate google domain,
+    // For each country, we should add the appropriate google domain,
     // per:  https://en.wikipedia.org/wiki/List_of_Google_domains
+    //
+    // If we ever use any non-google domains for domain fronting,
+    // remember to:
+    //
+    // a) Add the appropriate pinning certificate(s) in
+    //    SignalServiceKit.podspec.
+    // b) Update reflectorHost accordingly.
     return @{
              // Egypt
              @"+20": @"google.com.eg",
@@ -60,7 +68,7 @@ NSString *const OWSCensorshipConfigurationReflectorHost = @"signal-reflector-mee
 
 - (BOOL)isCensoredPhoneNumber:(NSString *)e164PhonNumber
 {
-    for (NSString *countryCode in self.censoredCountryCodes.allKeys) {
+    for (NSString *countryCode in self.censoredCountryCodes) {
         if ([e164PhonNumber hasPrefix:countryCode]) {
             return YES;
         }

--- a/src/Network/OWSSignalService.m
+++ b/src/Network/OWSSignalService.m
@@ -1,12 +1,14 @@
 // Created by Michael Kirk on 12/20/16.
 // Copyright © 2016 Open Whisper Systems. All rights reserved.
 
+#import <AFNetworking/AFHTTPSessionManager.h>
+
 #import "OWSSignalService.h"
 #import "OWSCensorshipConfiguration.h"
 #import "OWSHTTPSecurityPolicy.h"
 #import "TSConstants.h"
 #import "TSAccountManager.h"
-#import <AFNetworking/AFHTTPSessionManager.h>
+#import "Asserts.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/Network/OWSSignalService.m
+++ b/src/Network/OWSSignalService.m
@@ -69,8 +69,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (AFHTTPSessionManager *)reflectorHTTPSessionManager
 {
+    NSString *localNumber = [TSAccountManager localNumber];
+    OWSAssert(localNumber.length > 0);
+
     // Target fronting domain
-    NSURL *baseURL = [[NSURL alloc] initWithString:self.censorshipConfiguration.frontingHost];
+    NSURL *baseURL = [[NSURL alloc] initWithString:[self.censorshipConfiguration frontingHost:localNumber]];
     NSURLSessionConfiguration *sessionConf = NSURLSessionConfiguration.ephemeralSessionConfiguration;
     AFHTTPSessionManager *sessionManager =
         [[AFHTTPSessionManager alloc] initWithBaseURL:baseURL sessionConfiguration:sessionConf];

--- a/src/Util/Asserts.h
+++ b/src/Util/Asserts.h
@@ -1,0 +1,30 @@
+//
+//  Asserts.h
+//
+//  Copyright (c) 2016 Open Whisper Systems. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#ifndef OWSAssert
+
+#ifdef DEBUG
+
+#define USE_ASSERTS
+
+#define CONVERT_TO_STRING(X) #X
+#define CONVERT_EXPR_TO_STRING(X) CONVERT_TO_STRING(X)
+
+#define OWSAssert(X) \
+if (!(X)) { \
+NSLog(@"Assertion failed: %s", CONVERT_EXPR_TO_STRING(X)); \
+NSAssert(0, @"Assertion failed: %s", CONVERT_EXPR_TO_STRING(X)); \
+}
+
+#else
+
+#define OWSAssert(X)
+
+#endif
+
+#endif

--- a/src/Util/Cryptography.m
+++ b/src/Util/Cryptography.m
@@ -10,7 +10,6 @@
 #import <CommonCrypto/CommonHMAC.h>
 
 #import "Cryptography.h"
-
 #import "NSData+Base64.h"
 
 #define HMAC256_KEY_LENGTH 32


### PR DESCRIPTION
This PR includes:

* Add censorship circumvention in Cuba, Oman per #1576.
* Add censorship circumvention in Iran per https://github.com/WhisperSystems/Signal-Android/issues/5992
* Update fronting to use a country-specific Google domain.
* I added Asserts.h.  I'd like to add it to the .pchs for SignalServiceKit and Signal-iOS.  
   * I'm wondering if we should modify SignalServiceKit to include an .xcodeproj file.

This PR does not include:

* This work isn't complete.  I'm not 100% clear on all of the changes that will be necessary.  
* I haven't tested - I'm not clear on how we'll test this.
* Do we need to bundle additional .crts with the app?  I suspect that GIAG2.crt is sufficient for all Google domains.

PTAL @michaelkirk 