### PR TITLE
Add class to track app version.

### DIFF
--- a/src/Util/AppVersion.h
+++ b/src/Util/AppVersion.h
@@ -1,0 +1,15 @@
+//
+//  AppVersion.h
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+@interface AppVersion : NSObject
+
+@property (nonatomic, readonly) NSString *firstAppVersion;
+@property (nonatomic, readonly) NSString *lastAppVersion;
+@property (nonatomic, readonly) NSString *currentAppVersion;
+
++ (instancetype)instance;
+
+@end

--- a/src/Util/AppVersion.m
+++ b/src/Util/AppVersion.m
@@ -1,0 +1,64 @@
+//
+//  AppVersion.m
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "AppVersion.h"
+
+@interface AppVersion ()
+
+@property (nonatomic) NSString *firstAppVersion;
+@property (nonatomic) NSString *lastAppVersion;
+@property (nonatomic) NSString *currentAppVersion;
+
+@end
+
+#pragma mark -
+
+@implementation AppVersion
+
++ (instancetype)instance {
+    static AppVersion *instance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [AppVersion new];
+        [instance configure];
+    });
+    return instance;
+}
+
+- (void)configure {
+    self.currentAppVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    
+    NSString *kNSUserDefaults_FirstAppVersion = @"kNSUserDefaults_FirstAppVersion";
+    NSString *kNSUserDefaults_LastAppVersion = @"kNSUserDefaults_LastVersion";
+    
+    // The version of the app when it was first launched.
+    // nil if the app has never been launched before.
+    self.firstAppVersion = [[NSUserDefaults standardUserDefaults] objectForKey:kNSUserDefaults_FirstAppVersion];
+    // The version of the app the last time it was launched.
+    // nil if the app has never been launched before.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+    self.lastAppVersion = [[NSUserDefaults standardUserDefaults] objectForKey:kNSUserDefaults_LastAppVersion];
+#pragma clang diagnostic pop
+    
+    // Ensure the value for the "first launched version".
+    if (!self.firstAppVersion) {
+        self.firstAppVersion = self.currentAppVersion;
+        [[NSUserDefaults standardUserDefaults] setObject:self.currentAppVersion
+                                                  forKey:kNSUserDefaults_FirstAppVersion];
+    }
+    
+    // Update the value for the "most recently launched version".
+    [[NSUserDefaults standardUserDefaults] setObject:self.currentAppVersion
+                                              forKey:kNSUserDefaults_LastAppVersion];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+
+    DDLogInfo(@"firstAppVersion: %@", self.firstAppVersion);
+    DDLogInfo(@"lastAppVersion: %@", self.lastAppVersion);
+    DDLogInfo(@"currentAppVersion: %@", self.currentAppVersion);
+}
+
+@end


### PR DESCRIPTION
Add an entity to track and report on app version history.  I've always found this kind of thing invaluable when debugging, to help notice that certain crashes only happen on clean installs, or certain issues only occur when upgrading from version X to Y, etc.

PTAL @michaelkirk 
