### PR TITLE
Strip trailing whitespace in precommit script.

### DIFF
--- a/Example/TSKitiOSTestApp/Podfile.lock
+++ b/Example/TSKitiOSTestApp/Podfile.lock
@@ -35,7 +35,7 @@ PODS:
   - ProtocolBuffers (1.9.10)
   - Reachability (3.2)
   - SAMKeychain (1.5.0)
-  - SignalServiceKit (0.8.0):
+  - SignalServiceKit (0.8.1):
     - '25519'
     - AFNetworking
     - AxolotlKit
@@ -130,7 +130,7 @@ SPEC CHECKSUMS:
   ProtocolBuffers: d088180c10072b3d24a9939a6314b7b9bcc2340b
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SAMKeychain: 1fc9ae02f576365395758b12888c84704eebc423
-  SignalServiceKit: b4b9e425f4043ed74dd07e243de18de401252462
+  SignalServiceKit: 60f92ec89fbbf3196bd786b88f065c0214db9ca8
   SocketRocket: 3f77ec2104cc113add553f817ad90a77114f5d43
   SQLCipher: 4c768761421736a247ed6cf412d9045615d53dff
   TwistedOakCollapsingFutures: f359b90f203e9ab13dfb92c9ff41842a7fe1cd0c

--- a/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		45731A6C1DA87AA1007E22AA /* TSOutgoingMessageTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 45731A6B1DA87AA1007E22AA /* TSOutgoingMessageTest.m */; };
 		459850C11D22C6F2006FFEDB /* PhoneNumberTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 459850C01D22C6F2006FFEDB /* PhoneNumberTest.m */; };
 		45A856AC1D220BFF0056CD4D /* TSAttributesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 45A856AB1D220BFF0056CD4D /* TSAttributesTest.m */; };
+		45AE48491E072711004D96C2 /* OWSUnitTestEnvironment.m in Sources */ = {isa = PBXBuildFile; fileRef = 45AE48481E072711004D96C2 /* OWSUnitTestEnvironment.m */; };
+		45AE484C1E072871004D96C2 /* OWSFakeCallMessageHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 45AE484B1E072871004D96C2 /* OWSFakeCallMessageHandler.m */; };
+		45AE484F1E072906004D96C2 /* OWSFakeNotificationsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 45AE484E1E072906004D96C2 /* OWSFakeNotificationsManager.m */; };
 		45B700971D9841E400269FFD /* OWSDisappearingMessagesConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 45B700961D9841E400269FFD /* OWSDisappearingMessagesConfigurationTest.m */; };
 		45B840211D988DA100F9E938 /* OWSReadReceiptTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 45B840201D988DA100F9E938 /* OWSReadReceiptTest.m */; };
 		45C6A09A1D2F029B007D8AC0 /* TSMessageTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 45C6A0991D2F029B007D8AC0 /* TSMessageTest.m */; };
@@ -86,6 +89,12 @@
 		459850C01D22C6F2006FFEDB /* PhoneNumberTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PhoneNumberTest.m; path = ../../../tests/Contacts/PhoneNumberTest.m; sourceTree = "<group>"; };
 		459FE0DA1D4AD49E00E1071A /* TSKitiOSTestApp-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TSKitiOSTestApp-Prefix.pch"; sourceTree = "<group>"; };
 		45A856AB1D220BFF0056CD4D /* TSAttributesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSAttributesTest.m; sourceTree = "<group>"; };
+		45AE48471E072711004D96C2 /* OWSUnitTestEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OWSUnitTestEnvironment.h; path = ../../../tests/TestSupport/Fakes/OWSUnitTestEnvironment.h; sourceTree = "<group>"; };
+		45AE48481E072711004D96C2 /* OWSUnitTestEnvironment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OWSUnitTestEnvironment.m; path = ../../../tests/TestSupport/Fakes/OWSUnitTestEnvironment.m; sourceTree = "<group>"; };
+		45AE484A1E072871004D96C2 /* OWSFakeCallMessageHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OWSFakeCallMessageHandler.h; path = ../../../tests/TestSupport/Fakes/OWSFakeCallMessageHandler.h; sourceTree = "<group>"; };
+		45AE484B1E072871004D96C2 /* OWSFakeCallMessageHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OWSFakeCallMessageHandler.m; path = ../../../tests/TestSupport/Fakes/OWSFakeCallMessageHandler.m; sourceTree = "<group>"; };
+		45AE484D1E072906004D96C2 /* OWSFakeNotificationsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OWSFakeNotificationsManager.h; path = ../../../tests/TestSupport/Fakes/OWSFakeNotificationsManager.h; sourceTree = "<group>"; };
+		45AE484E1E072906004D96C2 /* OWSFakeNotificationsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OWSFakeNotificationsManager.m; path = ../../../tests/TestSupport/Fakes/OWSFakeNotificationsManager.m; sourceTree = "<group>"; };
 		45B700961D9841E400269FFD /* OWSDisappearingMessagesConfigurationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OWSDisappearingMessagesConfigurationTest.m; path = ../../../tests/Contacts/OWSDisappearingMessagesConfigurationTest.m; sourceTree = "<group>"; };
 		45B840201D988DA100F9E938 /* OWSReadReceiptTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OWSReadReceiptTest.m; path = ../../../tests/Devices/OWSReadReceiptTest.m; sourceTree = "<group>"; };
 		45C6A0991D2F029B007D8AC0 /* TSMessageTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TSMessageTest.m; path = ../../../tests/Messages/Interactions/TSMessageTest.m; sourceTree = "<group>"; };
@@ -147,6 +156,12 @@
 				453E1FDA1DA83EFB00DDD7B7 /* OWSFakeContactsUpdater.m */,
 				454092F81DB7AFDE00579DE1 /* OWSFakeNetworkManager.h */,
 				454092F91DB7AFDE00579DE1 /* OWSFakeNetworkManager.m */,
+				45AE48471E072711004D96C2 /* OWSUnitTestEnvironment.h */,
+				45AE48481E072711004D96C2 /* OWSUnitTestEnvironment.m */,
+				45AE484A1E072871004D96C2 /* OWSFakeCallMessageHandler.h */,
+				45AE484B1E072871004D96C2 /* OWSFakeCallMessageHandler.m */,
+				45AE484D1E072906004D96C2 /* OWSFakeNotificationsManager.h */,
+				45AE484E1E072906004D96C2 /* OWSFakeNotificationsManager.m */,
 			);
 			name = Fakes;
 			sourceTree = "<group>";
@@ -552,6 +567,8 @@
 				45458B761CC342B600A02153 /* TSAttachmentsTest.m in Sources */,
 				45C6A09A1D2F029B007D8AC0 /* TSMessageTest.m in Sources */,
 				453E1FCF1DA8313100DDD7B7 /* OWSMessageSenderTest.m in Sources */,
+				45AE484C1E072871004D96C2 /* OWSFakeCallMessageHandler.m in Sources */,
+				45AE48491E072711004D96C2 /* OWSUnitTestEnvironment.m in Sources */,
 				459850C11D22C6F2006FFEDB /* PhoneNumberTest.m in Sources */,
 				45458B7A1CC342B600A02153 /* TSStorageSignedPreKeyStore.m in Sources */,
 				453E1FDB1DA83EFB00DDD7B7 /* OWSFakeContactsUpdater.m in Sources */,
@@ -565,6 +582,7 @@
 				45A856AC1D220BFF0056CD4D /* TSAttributesTest.m in Sources */,
 				45731A6C1DA87AA1007E22AA /* TSOutgoingMessageTest.m in Sources */,
 				6323E339D5B8F4CB77EB3ED4 /* SignalRecipientTest.m in Sources */,
+				45AE484F1E072906004D96C2 /* OWSFakeNotificationsManager.m in Sources */,
 				6323E1F7730289398452E5C5 /* OWSFingerprintTest.m in Sources */,
 				454092FA1DB7AFDE00579DE1 /* OWSFakeNetworkManager.m in Sources */,
 			);

--- a/Utilities/precommit.py
+++ b/Utilities/precommit.py
@@ -34,6 +34,7 @@ def process(filepath):
     original_text = text
     
     lines = text.split('\n')
+    lines = [line.rstrip() for line in lines]
     while lines and lines[0].startswith('//'):
         lines = lines[1:]
     text = '\n'.join(lines)

--- a/protobuf/OWSSignalServiceProtos.proto
+++ b/protobuf/OWSSignalServiceProtos.proto
@@ -33,6 +33,41 @@ message Envelope {
 message Content {
   optional DataMessage dataMessage = 1;
   optional SyncMessage syncMessage = 2;
+  optional CallMessage callMessage = 3;
+}
+
+message CallMessage {
+  message Offer {
+    optional uint64 id          = 1;
+    optional string sessionDescription = 2;
+  }
+
+  message Answer {
+    optional uint64 id          = 1;
+    optional string sessionDescription = 2;
+  }
+
+  message IceUpdate {
+    optional uint64 id            = 1;
+    optional string sdpMid        = 2;
+    optional uint32 sdpMLineIndex = 3;
+    optional string sdp           = 4;
+  }
+
+  message Busy {
+    optional uint64 id = 1;
+  }
+
+  message Hangup {
+    optional uint64 id = 1;
+  }
+
+
+  optional Offer     offer     = 1;
+  optional Answer    answer    = 2;
+  repeated IceUpdate iceUpdate = 3;
+  optional Hangup    hangup    = 4;
+  optional Busy      busy      = 5;
 }
 
 message DataMessage {

--- a/src/Account/TSAccountManager.h
+++ b/src/Account/TSAccountManager.h
@@ -19,10 +19,14 @@ static NSString *const TSRegistrationErrorUserInfoHTTPStatus = @"TSHTTPStatus";
 
 @interface TSAccountManager : NSObject
 
+#pragma mark - Initializers
+
 - (instancetype)initWithNetworkManager:(TSNetworkManager *)networkManager
                         storageManager:(TSStorageManager *)storageManager;
 
 + (instancetype)sharedInstance;
+
+@property (nonatomic, strong, readonly) TSNetworkManager *networkManager;
 
 /**
  *  Returns if a user is registered or not

--- a/src/Account/TSAccountManager.m
+++ b/src/Account/TSAccountManager.m
@@ -23,7 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TSAccountManager ()
 
 @property (nullable, nonatomic, retain) NSString *phoneNumberAwaitingVerification;
-@property (nonatomic, strong, readonly) TSNetworkManager *networkManager;
 @property (nonatomic, strong, readonly) TSStorageManager *storageManager;
 
 @end

--- a/src/Contacts/PhoneNumberUtil.m
+++ b/src/Contacts/PhoneNumberUtil.m
@@ -1,6 +1,7 @@
-#import "Constraints.h"
-#import "FunctionalUtil.h"
 #import "PhoneNumberUtil.h"
+#import "Constraints.h"
+#import "ContactsManagerProtocol.h"
+#import "FunctionalUtil.h"
 #import "TextSecureKitEnv.h"
 #import "Util.h"
 

--- a/src/Contacts/Threads/TSContactThread.h
+++ b/src/Contacts/Threads/TSContactThread.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface TSContactThread : TSThread
 
-+ (instancetype)getOrCreateThreadWithContactId:(NSString *)contactId;
++ (instancetype)getOrCreateThreadWithContactId:(NSString *)contactId NS_SWIFT_NAME(getOrCreateThread(contactId:));
 
 + (instancetype)getOrCreateThreadWithContactId:(NSString *)contactId
                                    transaction:(YapDatabaseReadWriteTransaction *)transaction;

--- a/src/Contacts/Threads/TSContactThread.m
+++ b/src/Contacts/Threads/TSContactThread.m
@@ -2,7 +2,9 @@
 //  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
 
 #import "TSContactThread.h"
+#import "ContactsManagerProtocol.h"
 #import "ContactsUpdater.h"
+#import "NotificationsProtocol.h"
 #import "TSStorageManager+identityKeyStore.h"
 #import "TextSecureKitEnv.h"
 #import <YapDatabase/YapDatabaseConnection.h>

--- a/src/Messages/DeviceSyncing/OWSOutgoingSyncMessage.m
+++ b/src/Messages/DeviceSyncing/OWSOutgoingSyncMessage.m
@@ -19,10 +19,16 @@ NS_ASSUME_NONNULL_BEGIN
     return NO;
 }
 
+- (BOOL)isLegacyMessage
+{
+    return NO;
+}
+
 - (OWSSignalServiceProtosSyncMessage *)buildSyncMessage
 {
     NSAssert(NO, @"buildSyncMessage must be overridden in subclass");
 
+    // e.g.
     OWSSignalServiceProtosSyncMessageBuilder *syncMessageBuilder = [OWSSignalServiceProtosSyncMessageBuilder new];
     return [syncMessageBuilder build];
 }

--- a/src/Messages/Interactions/TSErrorMessage.m
+++ b/src/Messages/Interactions/TSErrorMessage.m
@@ -7,6 +7,7 @@
 //
 
 #import "TSErrorMessage.h"
+#import "NotificationsProtocol.h"
 #import "TSContactThread.h"
 #import "TSErrorMessage_privateConstructor.h"
 #import "TSMessagesManager.h"
@@ -35,7 +36,7 @@
     }
 
     _errorType = errorMessageType;
-
+    // TODO Move this out of model class.
     [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForErrorMessage:self inThread:thread];
 
     return self;

--- a/src/Messages/Interactions/TSMessage.m
+++ b/src/Messages/Interactions/TSMessage.m
@@ -134,7 +134,7 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
     return self;
 }
 
-- (void)setexpiresInSeconds:(uint32_t)expiresInSeconds
+- (void)setExpiresInSeconds:(uint32_t)expiresInSeconds
 {
     _expiresInSeconds = expiresInSeconds;
     [self updateExpiresAt];

--- a/src/Messages/Interactions/TSOutgoingMessage.h
+++ b/src/Messages/Interactions/TSOutgoingMessage.h
@@ -49,6 +49,13 @@ typedef NS_ENUM(NSInteger, TSOutgoingMessageState) {
 @property NSString *customMessage;
 @property (atomic, readonly) NSString *mostRecentFailureText;
 
+/**
+ * Whether the message should be serialized as a modern aka Content, or the old style legacy message.
+ * Sync and Call messsages must be sent as Content, but other old style DataMessage payloads should be
+ * sent as legacy message until we're confident no significant number of legacy clients exist in the wild.
+ */
+@property (nonatomic, readonly) BOOL isLegacyMessage;
+
 - (void)setSendingError:(NSError *)error;
 
 /**

--- a/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/src/Messages/Interactions/TSOutgoingMessage.m
@@ -170,9 +170,16 @@ NS_ASSUME_NONNULL_BEGIN
     return [[self dataMessageBuilder] build];
 }
 
+// For legacy message this is a serialized DataMessage.
+// For modern messages, e.g. Sync and Call messages, this is a serialized Contact
 - (NSData *)buildPlainTextData
 {
     return [[self buildDataMessage] data];
+}
+
+- (BOOL)isLegacyMessage
+{
+    return YES;
 }
 
 - (BOOL)shouldSyncTranscript

--- a/src/Messages/OWSCallAnswerMessage.h
+++ b/src/Messages/OWSCallAnswerMessage.h
@@ -1,0 +1,19 @@
+//  Created by Michael Kirk on 12/1/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class OWSSignalServiceProtosCallMessageAnswer;
+
+@interface OWSCallAnswerMessage : NSObject
+
+- (instancetype)initWithCallId:(UInt64)callId sessionDescription:(NSString *)sessionDescription;
+
+@property (nonatomic, readonly) UInt64 callId;
+@property (nonatomic, readonly, copy) NSString *sessionDescription;
+
+- (OWSSignalServiceProtosCallMessageAnswer *)asProtobuf;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSCallAnswerMessage.m
+++ b/src/Messages/OWSCallAnswerMessage.m
@@ -1,0 +1,36 @@
+//  Created by Michael Kirk on 12/1/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSCallAnswerMessage.h"
+#import "OWSSignalServiceProtos.pb.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSCallAnswerMessage
+
+- (instancetype)initWithCallId:(UInt64)callId sessionDescription:(NSString *)sessionDescription
+{
+    self = [super init];
+    if (!self) {
+        return self;
+    }
+
+    _callId = callId;
+    _sessionDescription = sessionDescription;
+
+    return self;
+}
+
+- (OWSSignalServiceProtosCallMessageAnswer *)asProtobuf
+{
+    OWSSignalServiceProtosCallMessageAnswerBuilder *builder = [OWSSignalServiceProtosCallMessageAnswerBuilder new];
+
+    builder.id = self.callId;
+    builder.sessionDescription = self.sessionDescription;
+
+    return [builder build];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSCallBusyMessage.h
+++ b/src/Messages/OWSCallBusyMessage.h
@@ -1,0 +1,20 @@
+//  Created by Michael Kirk on 12/1/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSOutgoingCallMessage.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class OWSSignalServiceProtosCallMessageBusy;
+
+@interface OWSCallBusyMessage : OWSOutgoingCallMessage
+
+- (instancetype)initWithCallId:(UInt64)callId;
+
+@property (nonatomic, readonly) UInt64 callId;
+
+- (OWSSignalServiceProtosCallMessageBusy *)asProtobuf;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSCallBusyMessage.m
+++ b/src/Messages/OWSCallBusyMessage.m
@@ -1,0 +1,35 @@
+//  Created by Michael Kirk on 12/1/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSCallBusyMessage.h"
+#import "OWSSignalServiceProtos.pb.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSCallBusyMessage
+
+- (instancetype)initWithCallId:(UInt64)callId
+{
+    self = [super init];
+    if (!self) {
+        return self;
+    }
+
+    _callId = callId;
+
+    return self;
+}
+
+- (OWSSignalServiceProtosCallMessageBusy *)asProtobuf
+{
+    OWSSignalServiceProtosCallMessageBusyBuilder *builder = [OWSSignalServiceProtosCallMessageBusyBuilder new];
+
+    builder.id = self.callId;
+
+    return [builder build];
+}
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSCallHangupMessage.h
+++ b/src/Messages/OWSCallHangupMessage.h
@@ -1,0 +1,20 @@
+//  Created by Michael Kirk on 12/8/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSOutgoingCallMessage.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class OWSSignalServiceProtosCallMessageHangup;
+
+@interface OWSCallHangupMessage : OWSOutgoingCallMessage
+
+- (instancetype)initWithCallId:(UInt64)callId;
+
+@property (nonatomic, readonly) UInt64 callId;
+
+- (OWSSignalServiceProtosCallMessageHangup *)asProtobuf;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSCallHangupMessage.m
+++ b/src/Messages/OWSCallHangupMessage.m
@@ -1,0 +1,35 @@
+//  Created by Michael Kirk on 12/8/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSCallHangupMessage.h"
+#import "OWSSignalServiceProtos.pb.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSCallHangupMessage
+
+- (instancetype)initWithCallId:(UInt64)callId
+{
+    self = [super init];
+    if (!self) {
+        return self;
+    }
+
+    _callId = callId;
+
+    return self;
+}
+
+- (OWSSignalServiceProtosCallMessageHangup *)asProtobuf
+{
+    OWSSignalServiceProtosCallMessageHangupBuilder *builder = [OWSSignalServiceProtosCallMessageHangupBuilder new];
+
+    builder.id = self.callId;
+
+    return [builder build];
+}
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSCallIceUpdateMessage.h
+++ b/src/Messages/OWSCallIceUpdateMessage.h
@@ -1,0 +1,24 @@
+//  Created by Michael Kirk on 12/6/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class OWSSignalServiceProtosCallMessageIceUpdate;
+
+@interface OWSCallIceUpdateMessage : NSObject
+
+- (instancetype)initWithCallId:(UInt64)callId
+                           sdp:(NSString *)sdp
+                 sdpMLineIndex:(SInt32)sdpMLineIndex
+                        sdpMid:(nullable NSString *)sdpMid;
+
+@property (nonatomic, readonly) UInt64 callId;
+@property (nonatomic, readonly, copy) NSString *sdp;
+@property (nonatomic, readonly) SInt32 sdpMLineIndex;
+@property (nullable, nonatomic, readonly, copy) NSString *sdpMid;
+
+- (OWSSignalServiceProtosCallMessageIceUpdate *)asProtobuf;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSCallIceUpdateMessage.m
+++ b/src/Messages/OWSCallIceUpdateMessage.m
@@ -1,0 +1,40 @@
+//  Created by Michael Kirk on 12/6/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSCallIceUpdateMessage.h"
+#import "OWSSignalServiceProtos.pb.h"
+
+@implementation OWSCallIceUpdateMessage
+
+- (instancetype)initWithCallId:(UInt64)callId
+                           sdp:(NSString *)sdp
+                 sdpMLineIndex:(SInt32)sdpMLineIndex
+                        sdpMid:(nullable NSString *)sdpMid
+{
+    self = [super init];
+    if (!self) {
+        return self;
+    }
+
+    _callId = callId;
+    _sdp = sdp;
+    _sdpMLineIndex = sdpMLineIndex;
+    _sdpMid = sdpMid;
+
+    return self;
+}
+
+- (OWSSignalServiceProtosCallMessageIceUpdate *)asProtobuf
+{
+    OWSSignalServiceProtosCallMessageIceUpdateBuilder *builder =
+        [OWSSignalServiceProtosCallMessageIceUpdateBuilder new];
+
+    [builder setId:self.callId];
+    [builder setSdp:self.sdp];
+    [builder setSdpMlineIndex:self.sdpMLineIndex];
+    [builder setSdpMid:self.sdpMid];
+
+    return [builder build];
+}
+
+@end

--- a/src/Messages/OWSCallOfferMessage.h
+++ b/src/Messages/OWSCallOfferMessage.h
@@ -1,0 +1,19 @@
+//  Created by Michael Kirk on 12/1/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class OWSSignalServiceProtosCallMessageOffer;
+
+@interface OWSCallOfferMessage : NSObject
+
+- (instancetype)initWithCallId:(UInt64)callId sessionDescription:(NSString *)sessionDescription;
+
+@property (nonatomic, readonly) UInt64 callId;
+@property (nonatomic, readonly, copy) NSString *sessionDescription;
+
+- (OWSSignalServiceProtosCallMessageOffer *)asProtobuf;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSCallOfferMessage.m
+++ b/src/Messages/OWSCallOfferMessage.m
@@ -1,0 +1,36 @@
+//  Created by Michael Kirk on 12/1/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSCallOfferMessage.h"
+#import "OWSSignalServiceProtos.pb.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSCallOfferMessage
+
+- (instancetype)initWithCallId:(UInt64)callId sessionDescription:(NSString *)sessionDescription
+{
+    self = [super init];
+    if (!self) {
+        return self;
+    }
+
+    _callId = callId;
+    _sessionDescription = sessionDescription;
+
+    return self;
+}
+
+- (OWSSignalServiceProtosCallMessageOffer *)asProtobuf
+{
+    OWSSignalServiceProtosCallMessageOfferBuilder *builder = [OWSSignalServiceProtosCallMessageOfferBuilder new];
+
+    builder.id = self.callId;
+    builder.sessionDescription = self.sessionDescription;
+
+    return [builder build];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -434,7 +434,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
         }
 
         if ([exception.name isEqualToString:OWSMessageSenderRateLimitedException]) {
-            NSError *error = OWSErrorWithCodeDescription(OWSErrorCodeUntrustedIdentityKey,
+            NSError *error = OWSErrorWithCodeDescription(OWSErrorCodeSingalServiceRateLimited,
                 NSLocalizedString(@"FAILED_SENDING_BECAUSE_RATE_LIMIT",
                     @"action sheet header when re-sending message which failed because of too many attempts"));
             return failureHandler(error);

--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -83,6 +83,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             success:(void (^)())successHandler
             failure:(void (^)(NSError *error))failureHandler
 {
+    DDLogDebug(@"%@ sending message: %@", self.tag, message.debugDescription);
     void (^markAndFailureHandler)(NSError *error) = ^(NSError *error) {
         [self saveMessage:message withError:error];
         failureHandler(error);
@@ -625,14 +626,11 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
 
     for (NSNumber *deviceNumber in recipient.devices) {
         @try {
-            // DEPRECATED - Remove after all clients have been upgraded.
-            BOOL isLegacyMessage = ![message isKindOfClass:[OWSOutgoingSyncMessage class]];
-
             NSDictionary *messageDict = [self encryptedMessageWithPlaintext:plainText
                                                                 toRecipient:recipient.uniqueId
                                                                    deviceId:deviceNumber
                                                               keyingStorage:[TSStorageManager sharedManager]
-                                                                     legacy:isLegacyMessage];
+                                                                     legacy:message.isLegacyMessage];
             if (messageDict) {
                 [messagesArray addObject:messageDict];
             } else {

--- a/src/Messages/OWSOutgoingCallMessage.h
+++ b/src/Messages/OWSOutgoingCallMessage.h
@@ -1,0 +1,34 @@
+//  Created by Michael Kirk on 12/1/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "TSOutgoingMessage.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class OWSCallOfferMessage;
+@class OWSCallAnswerMessage;
+@class OWSCallIceUpdateMessage;
+@class OWSCallHangupMessage;
+@class OWSCallBusyMessage;
+
+@class TSThread;
+
+@interface OWSOutgoingCallMessage : TSOutgoingMessage
+
+- (instancetype)initWithThread:(TSThread *)thread offerMessage:(OWSCallOfferMessage *)offerMessage;
+- (instancetype)initWithThread:(TSThread *)thread answerMessage:(OWSCallAnswerMessage *)answerMessage;
+- (instancetype)initWithThread:(TSThread *)thread iceUpdateMessage:(OWSCallIceUpdateMessage *)iceUpdateMessage;
+- (instancetype)initWithThread:(TSThread *)thread
+             iceUpdateMessages:(NSArray<OWSCallIceUpdateMessage *> *)iceUpdateMessage;
+- (instancetype)initWithThread:(TSThread *)thread hangupMessage:(OWSCallHangupMessage *)hangupMessage;
+- (instancetype)initWithThread:(TSThread *)thread busyMessage:(OWSCallBusyMessage *)busyMessage;
+
+@property (nullable, nonatomic, readonly, strong) OWSCallOfferMessage *offerMessage;
+@property (nullable, nonatomic, readonly, strong) OWSCallAnswerMessage *answerMessage;
+@property (nullable, nonatomic, readonly, strong) NSArray<OWSCallIceUpdateMessage *> *iceUpdateMessages;
+@property (nullable, nonatomic, readonly, strong) OWSCallHangupMessage *hangupMessage;
+@property (nullable, nonatomic, readonly, strong) OWSCallBusyMessage *busyMessage;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSOutgoingCallMessage.m
+++ b/src/Messages/OWSOutgoingCallMessage.m
@@ -1,0 +1,198 @@
+//  Created by Michael Kirk on 12/1/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSOutgoingCallMessage.h"
+#import "NSDate+millisecondTimeStamp.h"
+#import "OWSCallAnswerMessage.h"
+#import "OWSCallBusyMessage.h"
+#import "OWSCallHangupMessage.h"
+#import "OWSCallIceUpdateMessage.h"
+#import "OWSCallOfferMessage.h"
+#import "OWSSignalServiceProtos.pb.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSOutgoingCallMessage
+
+//@synthesize thread = _thread;
+
+- (instancetype)initWithThread:(TSThread *)thread
+{
+    // These records aren't saved, but their timestamp is used in the event
+    // of a failing message send to insert the error at the appropriate place.
+    self = [super initWithTimestamp:[NSDate ows_millisecondTimeStamp] inThread:thread];
+    if (!self) {
+        return self;
+    }
+
+    return self;
+}
+
+
+- (instancetype)initWithThread:(TSThread *)thread offerMessage:(OWSCallOfferMessage *)offerMessage
+{
+    self = [self initWithThread:thread];
+    if (!self) {
+        return self;
+    }
+
+    _offerMessage = offerMessage;
+
+    return self;
+}
+
+- (instancetype)initWithThread:(TSThread *)thread answerMessage:(OWSCallAnswerMessage *)answerMessage
+{
+    self = [self initWithThread:thread];
+    if (!self) {
+        return self;
+    }
+
+    _answerMessage = answerMessage;
+
+    return self;
+}
+
+- (instancetype)initWithThread:(TSThread *)thread iceUpdateMessage:(OWSCallIceUpdateMessage *)iceUpdateMessage
+{
+    self = [self initWithThread:thread];
+    if (!self) {
+        return self;
+    }
+
+    _iceUpdateMessages = @[ iceUpdateMessage ];
+
+    return self;
+}
+
+- (instancetype)initWithThread:(TSThread *)thread
+             iceUpdateMessages:(NSArray<OWSCallIceUpdateMessage *> *)iceUpdateMessages
+{
+    self = [self initWithThread:thread];
+    if (!self) {
+        return self;
+    }
+
+    _iceUpdateMessages = iceUpdateMessages;
+
+    return self;
+}
+
+- (instancetype)initWithThread:(TSThread *)thread hangupMessage:(OWSCallHangupMessage *)hangupMessage
+{
+    self = [self initWithThread:thread];
+    if (!self) {
+        return self;
+    }
+
+    _hangupMessage = hangupMessage;
+
+    return self;
+}
+
+- (instancetype)initWithThread:(TSThread *)thread busyMessage:(OWSCallBusyMessage *)busyMessage
+{
+    self = [self initWithThread:thread];
+    if (!self) {
+        return self;
+    }
+
+    _busyMessage = busyMessage;
+
+    return self;
+}
+
+#pragma mark - TSOutgoingMessage overrides
+
+- (BOOL)shouldSyncTranscript
+{
+    return NO;
+}
+
+- (BOOL)isLegacyMessage
+{
+    return NO;
+}
+//
+///**
+// * override thread accessor in superclass, since this model is never saved.
+// * TODO review
+// */
+//- (TSThread *)thread
+//{
+//    return _thread;
+//}
+
+- (NSData *)buildPlainTextData
+{
+    OWSSignalServiceProtosContentBuilder *contentBuilder = [OWSSignalServiceProtosContentBuilder new];
+    [contentBuilder setCallMessage:[self asProtobuf]];
+
+    return [[contentBuilder build] data];
+}
+
+- (OWSSignalServiceProtosCallMessage *)asProtobuf
+{
+    OWSSignalServiceProtosCallMessageBuilder *builder = [OWSSignalServiceProtosCallMessageBuilder new];
+
+    if (self.offerMessage) {
+        [builder setOffer:[self.offerMessage asProtobuf]];
+    }
+
+    if (self.answerMessage) {
+        [builder setAnswer:[self.answerMessage asProtobuf]];
+    }
+
+    if (self.iceUpdateMessages) {
+        for (OWSCallIceUpdateMessage *iceUpdateMessage in self.iceUpdateMessages) {
+            [builder addIceUpdate:[iceUpdateMessage asProtobuf]];
+        }
+    }
+
+    if (self.hangupMessage) {
+        [builder setHangup:[self.hangupMessage asProtobuf]];
+    }
+
+    if (self.busyMessage) {
+        [builder setBusy:[self.busyMessage asProtobuf]];
+    }
+
+    return [builder build];
+}
+
+#pragma mark - TSYapDatabaseObject overrides
+
+- (void)saveWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
+{
+    // override superclass with no-op.
+    //
+    // There's no need to save this message, since it's not displayed to the user.
+    //
+    // Should we find a need to save this in the future, we need to exclude any non-serializable properties.
+}
+
+- (NSString *)debugDescription
+{
+    NSString *className = NSStringFromClass([self class]);
+
+    NSString *payload;
+    if (self.offerMessage) {
+        payload = @"offerMessage";
+    } else if (self.answerMessage) {
+        payload = @"answerMessage";
+    } else if (self.iceUpdateMessages.count > 0) {
+        payload = @"iceUpdateMessage";
+    } else if (self.hangupMessage) {
+        payload = @"hangupMessage";
+    } else if (self.busyMessage) {
+        payload = @"busyMessage";
+    } else {
+        payload = @"none";
+    }
+
+    return [NSString stringWithFormat:@"%@ with payload: %@", className, payload];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSSignalServiceProtos.pb.h
+++ b/src/Messages/OWSSignalServiceProtos.pb.h
@@ -6,6 +6,18 @@
 
 @class OWSSignalServiceProtosAttachmentPointer;
 @class OWSSignalServiceProtosAttachmentPointerBuilder;
+@class OWSSignalServiceProtosCallMessage;
+@class OWSSignalServiceProtosCallMessageAnswer;
+@class OWSSignalServiceProtosCallMessageAnswerBuilder;
+@class OWSSignalServiceProtosCallMessageBuilder;
+@class OWSSignalServiceProtosCallMessageBusy;
+@class OWSSignalServiceProtosCallMessageBusyBuilder;
+@class OWSSignalServiceProtosCallMessageHangup;
+@class OWSSignalServiceProtosCallMessageHangupBuilder;
+@class OWSSignalServiceProtosCallMessageIceUpdate;
+@class OWSSignalServiceProtosCallMessageIceUpdateBuilder;
+@class OWSSignalServiceProtosCallMessageOffer;
+@class OWSSignalServiceProtosCallMessageOfferBuilder;
 @class OWSSignalServiceProtosContactDetails;
 @class OWSSignalServiceProtosContactDetailsAvatar;
 @class OWSSignalServiceProtosContactDetailsAvatarBuilder;
@@ -240,17 +252,22 @@ NSString *NSStringFromOWSSignalServiceProtosGroupContextType(OWSSignalServicePro
 
 #define Content_dataMessage @"dataMessage"
 #define Content_syncMessage @"syncMessage"
+#define Content_callMessage @"callMessage"
 @interface OWSSignalServiceProtosContent : PBGeneratedMessage<GeneratedMessageProtocol> {
 @private
   BOOL hasDataMessage_:1;
   BOOL hasSyncMessage_:1;
+  BOOL hasCallMessage_:1;
   OWSSignalServiceProtosDataMessage* dataMessage;
   OWSSignalServiceProtosSyncMessage* syncMessage;
+  OWSSignalServiceProtosCallMessage* callMessage;
 }
 - (BOOL) hasDataMessage;
 - (BOOL) hasSyncMessage;
+- (BOOL) hasCallMessage;
 @property (readonly, strong) OWSSignalServiceProtosDataMessage* dataMessage;
 @property (readonly, strong) OWSSignalServiceProtosSyncMessage* syncMessage;
+@property (readonly, strong) OWSSignalServiceProtosCallMessage* callMessage;
 
 + (instancetype) defaultInstance;
 - (instancetype) defaultInstance;
@@ -300,6 +317,411 @@ NSString *NSStringFromOWSSignalServiceProtosGroupContextType(OWSSignalServicePro
 - (OWSSignalServiceProtosContentBuilder*) setSyncMessageBuilder:(OWSSignalServiceProtosSyncMessageBuilder*) builderForValue;
 - (OWSSignalServiceProtosContentBuilder*) mergeSyncMessage:(OWSSignalServiceProtosSyncMessage*) value;
 - (OWSSignalServiceProtosContentBuilder*) clearSyncMessage;
+
+- (BOOL) hasCallMessage;
+- (OWSSignalServiceProtosCallMessage*) callMessage;
+- (OWSSignalServiceProtosContentBuilder*) setCallMessage:(OWSSignalServiceProtosCallMessage*) value;
+- (OWSSignalServiceProtosContentBuilder*) setCallMessageBuilder:(OWSSignalServiceProtosCallMessageBuilder*) builderForValue;
+- (OWSSignalServiceProtosContentBuilder*) mergeCallMessage:(OWSSignalServiceProtosCallMessage*) value;
+- (OWSSignalServiceProtosContentBuilder*) clearCallMessage;
+@end
+
+#define CallMessage_offer @"offer"
+#define CallMessage_answer @"answer"
+#define CallMessage_iceUpdate @"iceUpdate"
+#define CallMessage_hangup @"hangup"
+#define CallMessage_busy @"busy"
+@interface OWSSignalServiceProtosCallMessage : PBGeneratedMessage<GeneratedMessageProtocol> {
+@private
+  BOOL hasOffer_:1;
+  BOOL hasAnswer_:1;
+  BOOL hasHangup_:1;
+  BOOL hasBusy_:1;
+  OWSSignalServiceProtosCallMessageOffer* offer;
+  OWSSignalServiceProtosCallMessageAnswer* answer;
+  OWSSignalServiceProtosCallMessageHangup* hangup;
+  OWSSignalServiceProtosCallMessageBusy* busy;
+  NSMutableArray * iceUpdateArray;
+}
+- (BOOL) hasOffer;
+- (BOOL) hasAnswer;
+- (BOOL) hasHangup;
+- (BOOL) hasBusy;
+@property (readonly, strong) OWSSignalServiceProtosCallMessageOffer* offer;
+@property (readonly, strong) OWSSignalServiceProtosCallMessageAnswer* answer;
+@property (readonly, strong) NSArray<OWSSignalServiceProtosCallMessageIceUpdate*> * iceUpdate;
+@property (readonly, strong) OWSSignalServiceProtosCallMessageHangup* hangup;
+@property (readonly, strong) OWSSignalServiceProtosCallMessageBusy* busy;
+- (OWSSignalServiceProtosCallMessageIceUpdate*)iceUpdateAtIndex:(NSUInteger)index;
+
++ (instancetype) defaultInstance;
+- (instancetype) defaultInstance;
+
+- (BOOL) isInitialized;
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output;
+- (OWSSignalServiceProtosCallMessageBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessage*) prototype;
+- (OWSSignalServiceProtosCallMessageBuilder*) toBuilder;
+
++ (OWSSignalServiceProtosCallMessage*) parseFromData:(NSData*) data;
++ (OWSSignalServiceProtosCallMessage*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessage*) parseFromInputStream:(NSInputStream*) input;
++ (OWSSignalServiceProtosCallMessage*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessage*) parseFromCodedInputStream:(PBCodedInputStream*) input;
++ (OWSSignalServiceProtosCallMessage*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+@end
+
+#define Offer_id @"id"
+#define Offer_sessionDescription @"sessionDescription"
+@interface OWSSignalServiceProtosCallMessageOffer : PBGeneratedMessage<GeneratedMessageProtocol> {
+@private
+  BOOL hasId_:1;
+  BOOL hasSessionDescription_:1;
+  UInt64 id;
+  NSString* sessionDescription;
+}
+- (BOOL) hasId;
+- (BOOL) hasSessionDescription;
+@property (readonly) UInt64 id;
+@property (readonly, strong) NSString* sessionDescription;
+
++ (instancetype) defaultInstance;
+- (instancetype) defaultInstance;
+
+- (BOOL) isInitialized;
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output;
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageOfferBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageOfferBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessageOffer*) prototype;
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) toBuilder;
+
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromData:(NSData*) data;
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromInputStream:(NSInputStream*) input;
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromCodedInputStream:(PBCodedInputStream*) input;
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+@end
+
+@interface OWSSignalServiceProtosCallMessageOfferBuilder : PBGeneratedMessageBuilder {
+@private
+  OWSSignalServiceProtosCallMessageOffer* resultOffer;
+}
+
+- (OWSSignalServiceProtosCallMessageOffer*) defaultInstance;
+
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) clear;
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) clone;
+
+- (OWSSignalServiceProtosCallMessageOffer*) build;
+- (OWSSignalServiceProtosCallMessageOffer*) buildPartial;
+
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessageOffer*) other;
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input;
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+
+- (BOOL) hasId;
+- (UInt64) id;
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) setId:(UInt64) value;
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) clearId;
+
+- (BOOL) hasSessionDescription;
+- (NSString*) sessionDescription;
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) setSessionDescription:(NSString*) value;
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) clearSessionDescription;
+@end
+
+#define Answer_id @"id"
+#define Answer_sessionDescription @"sessionDescription"
+@interface OWSSignalServiceProtosCallMessageAnswer : PBGeneratedMessage<GeneratedMessageProtocol> {
+@private
+  BOOL hasId_:1;
+  BOOL hasSessionDescription_:1;
+  UInt64 id;
+  NSString* sessionDescription;
+}
+- (BOOL) hasId;
+- (BOOL) hasSessionDescription;
+@property (readonly) UInt64 id;
+@property (readonly, strong) NSString* sessionDescription;
+
++ (instancetype) defaultInstance;
+- (instancetype) defaultInstance;
+
+- (BOOL) isInitialized;
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output;
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageAnswerBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageAnswerBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessageAnswer*) prototype;
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) toBuilder;
+
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromData:(NSData*) data;
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromInputStream:(NSInputStream*) input;
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromCodedInputStream:(PBCodedInputStream*) input;
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+@end
+
+@interface OWSSignalServiceProtosCallMessageAnswerBuilder : PBGeneratedMessageBuilder {
+@private
+  OWSSignalServiceProtosCallMessageAnswer* resultAnswer;
+}
+
+- (OWSSignalServiceProtosCallMessageAnswer*) defaultInstance;
+
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) clear;
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) clone;
+
+- (OWSSignalServiceProtosCallMessageAnswer*) build;
+- (OWSSignalServiceProtosCallMessageAnswer*) buildPartial;
+
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessageAnswer*) other;
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input;
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+
+- (BOOL) hasId;
+- (UInt64) id;
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) setId:(UInt64) value;
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) clearId;
+
+- (BOOL) hasSessionDescription;
+- (NSString*) sessionDescription;
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) setSessionDescription:(NSString*) value;
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) clearSessionDescription;
+@end
+
+#define IceUpdate_id @"id"
+#define IceUpdate_sdpMid @"sdpMid"
+#define IceUpdate_sdpMLineIndex @"sdpMlineIndex"
+#define IceUpdate_sdp @"sdp"
+@interface OWSSignalServiceProtosCallMessageIceUpdate : PBGeneratedMessage<GeneratedMessageProtocol> {
+@private
+  BOOL hasId_:1;
+  BOOL hasSdpMid_:1;
+  BOOL hasSdp_:1;
+  BOOL hasSdpMlineIndex_:1;
+  UInt64 id;
+  NSString* sdpMid;
+  NSString* sdp;
+  UInt32 sdpMlineIndex;
+}
+- (BOOL) hasId;
+- (BOOL) hasSdpMid;
+- (BOOL) hasSdpMlineIndex;
+- (BOOL) hasSdp;
+@property (readonly) UInt64 id;
+@property (readonly, strong) NSString* sdpMid;
+@property (readonly) UInt32 sdpMlineIndex;
+@property (readonly, strong) NSString* sdp;
+
++ (instancetype) defaultInstance;
+- (instancetype) defaultInstance;
+
+- (BOOL) isInitialized;
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessageIceUpdate*) prototype;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) toBuilder;
+
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromData:(NSData*) data;
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromInputStream:(NSInputStream*) input;
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromCodedInputStream:(PBCodedInputStream*) input;
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+@end
+
+@interface OWSSignalServiceProtosCallMessageIceUpdateBuilder : PBGeneratedMessageBuilder {
+@private
+  OWSSignalServiceProtosCallMessageIceUpdate* resultIceUpdate;
+}
+
+- (OWSSignalServiceProtosCallMessageIceUpdate*) defaultInstance;
+
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clear;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clone;
+
+- (OWSSignalServiceProtosCallMessageIceUpdate*) build;
+- (OWSSignalServiceProtosCallMessageIceUpdate*) buildPartial;
+
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessageIceUpdate*) other;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+
+- (BOOL) hasId;
+- (UInt64) id;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) setId:(UInt64) value;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clearId;
+
+- (BOOL) hasSdpMid;
+- (NSString*) sdpMid;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) setSdpMid:(NSString*) value;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clearSdpMid;
+
+- (BOOL) hasSdpMlineIndex;
+- (UInt32) sdpMlineIndex;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) setSdpMlineIndex:(UInt32) value;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clearSdpMlineIndex;
+
+- (BOOL) hasSdp;
+- (NSString*) sdp;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) setSdp:(NSString*) value;
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clearSdp;
+@end
+
+#define Busy_id @"id"
+@interface OWSSignalServiceProtosCallMessageBusy : PBGeneratedMessage<GeneratedMessageProtocol> {
+@private
+  BOOL hasId_:1;
+  UInt64 id;
+}
+- (BOOL) hasId;
+@property (readonly) UInt64 id;
+
++ (instancetype) defaultInstance;
+- (instancetype) defaultInstance;
+
+- (BOOL) isInitialized;
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output;
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageBusyBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageBusyBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessageBusy*) prototype;
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) toBuilder;
+
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromData:(NSData*) data;
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromInputStream:(NSInputStream*) input;
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromCodedInputStream:(PBCodedInputStream*) input;
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+@end
+
+@interface OWSSignalServiceProtosCallMessageBusyBuilder : PBGeneratedMessageBuilder {
+@private
+  OWSSignalServiceProtosCallMessageBusy* resultBusy;
+}
+
+- (OWSSignalServiceProtosCallMessageBusy*) defaultInstance;
+
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) clear;
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) clone;
+
+- (OWSSignalServiceProtosCallMessageBusy*) build;
+- (OWSSignalServiceProtosCallMessageBusy*) buildPartial;
+
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessageBusy*) other;
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input;
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+
+- (BOOL) hasId;
+- (UInt64) id;
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) setId:(UInt64) value;
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) clearId;
+@end
+
+#define Hangup_id @"id"
+@interface OWSSignalServiceProtosCallMessageHangup : PBGeneratedMessage<GeneratedMessageProtocol> {
+@private
+  BOOL hasId_:1;
+  UInt64 id;
+}
+- (BOOL) hasId;
+@property (readonly) UInt64 id;
+
++ (instancetype) defaultInstance;
+- (instancetype) defaultInstance;
+
+- (BOOL) isInitialized;
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output;
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageHangupBuilder*) builder;
++ (OWSSignalServiceProtosCallMessageHangupBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessageHangup*) prototype;
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) toBuilder;
+
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromData:(NSData*) data;
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromInputStream:(NSInputStream*) input;
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromCodedInputStream:(PBCodedInputStream*) input;
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+@end
+
+@interface OWSSignalServiceProtosCallMessageHangupBuilder : PBGeneratedMessageBuilder {
+@private
+  OWSSignalServiceProtosCallMessageHangup* resultHangup;
+}
+
+- (OWSSignalServiceProtosCallMessageHangup*) defaultInstance;
+
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) clear;
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) clone;
+
+- (OWSSignalServiceProtosCallMessageHangup*) build;
+- (OWSSignalServiceProtosCallMessageHangup*) buildPartial;
+
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessageHangup*) other;
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input;
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+
+- (BOOL) hasId;
+- (UInt64) id;
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) setId:(UInt64) value;
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) clearId;
+@end
+
+@interface OWSSignalServiceProtosCallMessageBuilder : PBGeneratedMessageBuilder {
+@private
+  OWSSignalServiceProtosCallMessage* resultCallMessage;
+}
+
+- (OWSSignalServiceProtosCallMessage*) defaultInstance;
+
+- (OWSSignalServiceProtosCallMessageBuilder*) clear;
+- (OWSSignalServiceProtosCallMessageBuilder*) clone;
+
+- (OWSSignalServiceProtosCallMessage*) build;
+- (OWSSignalServiceProtosCallMessage*) buildPartial;
+
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessage*) other;
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input;
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry;
+
+- (BOOL) hasOffer;
+- (OWSSignalServiceProtosCallMessageOffer*) offer;
+- (OWSSignalServiceProtosCallMessageBuilder*) setOffer:(OWSSignalServiceProtosCallMessageOffer*) value;
+- (OWSSignalServiceProtosCallMessageBuilder*) setOfferBuilder:(OWSSignalServiceProtosCallMessageOfferBuilder*) builderForValue;
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeOffer:(OWSSignalServiceProtosCallMessageOffer*) value;
+- (OWSSignalServiceProtosCallMessageBuilder*) clearOffer;
+
+- (BOOL) hasAnswer;
+- (OWSSignalServiceProtosCallMessageAnswer*) answer;
+- (OWSSignalServiceProtosCallMessageBuilder*) setAnswer:(OWSSignalServiceProtosCallMessageAnswer*) value;
+- (OWSSignalServiceProtosCallMessageBuilder*) setAnswerBuilder:(OWSSignalServiceProtosCallMessageAnswerBuilder*) builderForValue;
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeAnswer:(OWSSignalServiceProtosCallMessageAnswer*) value;
+- (OWSSignalServiceProtosCallMessageBuilder*) clearAnswer;
+
+- (NSMutableArray<OWSSignalServiceProtosCallMessageIceUpdate*> *)iceUpdate;
+- (OWSSignalServiceProtosCallMessageIceUpdate*)iceUpdateAtIndex:(NSUInteger)index;
+- (OWSSignalServiceProtosCallMessageBuilder *)addIceUpdate:(OWSSignalServiceProtosCallMessageIceUpdate*)value;
+- (OWSSignalServiceProtosCallMessageBuilder *)setIceUpdateArray:(NSArray<OWSSignalServiceProtosCallMessageIceUpdate*> *)array;
+- (OWSSignalServiceProtosCallMessageBuilder *)clearIceUpdate;
+
+- (BOOL) hasHangup;
+- (OWSSignalServiceProtosCallMessageHangup*) hangup;
+- (OWSSignalServiceProtosCallMessageBuilder*) setHangup:(OWSSignalServiceProtosCallMessageHangup*) value;
+- (OWSSignalServiceProtosCallMessageBuilder*) setHangupBuilder:(OWSSignalServiceProtosCallMessageHangupBuilder*) builderForValue;
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeHangup:(OWSSignalServiceProtosCallMessageHangup*) value;
+- (OWSSignalServiceProtosCallMessageBuilder*) clearHangup;
+
+- (BOOL) hasBusy;
+- (OWSSignalServiceProtosCallMessageBusy*) busy;
+- (OWSSignalServiceProtosCallMessageBuilder*) setBusy:(OWSSignalServiceProtosCallMessageBusy*) value;
+- (OWSSignalServiceProtosCallMessageBuilder*) setBusyBuilder:(OWSSignalServiceProtosCallMessageBusyBuilder*) builderForValue;
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeBusy:(OWSSignalServiceProtosCallMessageBusy*) value;
+- (OWSSignalServiceProtosCallMessageBuilder*) clearBusy;
 @end
 
 #define DataMessage_body @"body"

--- a/src/Messages/OWSSignalServiceProtos.pb.m
+++ b/src/Messages/OWSSignalServiceProtos.pb.m
@@ -558,6 +558,7 @@ NSString *NSStringFromOWSSignalServiceProtosEnvelopeType(OWSSignalServiceProtosE
 @interface OWSSignalServiceProtosContent ()
 @property (strong) OWSSignalServiceProtosDataMessage* dataMessage;
 @property (strong) OWSSignalServiceProtosSyncMessage* syncMessage;
+@property (strong) OWSSignalServiceProtosCallMessage* callMessage;
 @end
 
 @implementation OWSSignalServiceProtosContent
@@ -576,10 +577,18 @@ NSString *NSStringFromOWSSignalServiceProtosEnvelopeType(OWSSignalServiceProtosE
   hasSyncMessage_ = !!_value_;
 }
 @synthesize syncMessage;
+- (BOOL) hasCallMessage {
+  return !!hasCallMessage_;
+}
+- (void) setHasCallMessage:(BOOL) _value_ {
+  hasCallMessage_ = !!_value_;
+}
+@synthesize callMessage;
 - (instancetype) init {
   if ((self = [super init])) {
     self.dataMessage = [OWSSignalServiceProtosDataMessage defaultInstance];
     self.syncMessage = [OWSSignalServiceProtosSyncMessage defaultInstance];
+    self.callMessage = [OWSSignalServiceProtosCallMessage defaultInstance];
   }
   return self;
 }
@@ -605,6 +614,9 @@ static OWSSignalServiceProtosContent* defaultOWSSignalServiceProtosContentInstan
   if (self.hasSyncMessage) {
     [output writeMessage:2 value:self.syncMessage];
   }
+  if (self.hasCallMessage) {
+    [output writeMessage:3 value:self.callMessage];
+  }
   [self.unknownFields writeToCodedOutputStream:output];
 }
 - (SInt32) serializedSize {
@@ -619,6 +631,9 @@ static OWSSignalServiceProtosContent* defaultOWSSignalServiceProtosContentInstan
   }
   if (self.hasSyncMessage) {
     size_ += computeMessageSize(2, self.syncMessage);
+  }
+  if (self.hasCallMessage) {
+    size_ += computeMessageSize(3, self.callMessage);
   }
   size_ += self.unknownFields.serializedSize;
   memoizedSerializedSize = size_;
@@ -667,6 +682,12 @@ static OWSSignalServiceProtosContent* defaultOWSSignalServiceProtosContentInstan
                          withIndent:[NSString stringWithFormat:@"%@  ", indent]];
     [output appendFormat:@"%@}\n", indent];
   }
+  if (self.hasCallMessage) {
+    [output appendFormat:@"%@%@ {\n", indent, @"callMessage"];
+    [self.callMessage writeDescriptionTo:output
+                         withIndent:[NSString stringWithFormat:@"%@  ", indent]];
+    [output appendFormat:@"%@}\n", indent];
+  }
   [self.unknownFields writeDescriptionTo:output withIndent:indent];
 }
 - (void) storeInDictionary:(NSMutableDictionary *)dictionary {
@@ -679,6 +700,11 @@ static OWSSignalServiceProtosContent* defaultOWSSignalServiceProtosContentInstan
    NSMutableDictionary *messageDictionary = [NSMutableDictionary dictionary]; 
    [self.syncMessage storeInDictionary:messageDictionary];
    [dictionary setObject:[NSDictionary dictionaryWithDictionary:messageDictionary] forKey:@"syncMessage"];
+  }
+  if (self.hasCallMessage) {
+   NSMutableDictionary *messageDictionary = [NSMutableDictionary dictionary]; 
+   [self.callMessage storeInDictionary:messageDictionary];
+   [dictionary setObject:[NSDictionary dictionaryWithDictionary:messageDictionary] forKey:@"callMessage"];
   }
   [self.unknownFields storeInDictionary:dictionary];
 }
@@ -695,6 +721,8 @@ static OWSSignalServiceProtosContent* defaultOWSSignalServiceProtosContentInstan
       (!self.hasDataMessage || [self.dataMessage isEqual:otherMessage.dataMessage]) &&
       self.hasSyncMessage == otherMessage.hasSyncMessage &&
       (!self.hasSyncMessage || [self.syncMessage isEqual:otherMessage.syncMessage]) &&
+      self.hasCallMessage == otherMessage.hasCallMessage &&
+      (!self.hasCallMessage || [self.callMessage isEqual:otherMessage.callMessage]) &&
       (self.unknownFields == otherMessage.unknownFields || (self.unknownFields != nil && [self.unknownFields isEqual:otherMessage.unknownFields]));
 }
 - (NSUInteger) hash {
@@ -704,6 +732,9 @@ static OWSSignalServiceProtosContent* defaultOWSSignalServiceProtosContentInstan
   }
   if (self.hasSyncMessage) {
     hashCode = hashCode * 31 + [self.syncMessage hash];
+  }
+  if (self.hasCallMessage) {
+    hashCode = hashCode * 31 + [self.callMessage hash];
   }
   hashCode = hashCode * 31 + [self.unknownFields hash];
   return hashCode;
@@ -754,6 +785,9 @@ static OWSSignalServiceProtosContent* defaultOWSSignalServiceProtosContentInstan
   if (other.hasSyncMessage) {
     [self mergeSyncMessage:other.syncMessage];
   }
+  if (other.hasCallMessage) {
+    [self mergeCallMessage:other.callMessage];
+  }
   [self mergeUnknownFields:other.unknownFields];
   return self;
 }
@@ -791,6 +825,15 @@ static OWSSignalServiceProtosContent* defaultOWSSignalServiceProtosContentInstan
         }
         [input readMessage:subBuilder extensionRegistry:extensionRegistry];
         [self setSyncMessage:[subBuilder buildPartial]];
+        break;
+      }
+      case 26: {
+        OWSSignalServiceProtosCallMessageBuilder* subBuilder = [OWSSignalServiceProtosCallMessage builder];
+        if (self.hasCallMessage) {
+          [subBuilder mergeFrom:self.callMessage];
+        }
+        [input readMessage:subBuilder extensionRegistry:extensionRegistry];
+        [self setCallMessage:[subBuilder buildPartial]];
         break;
       }
     }
@@ -854,6 +897,1824 @@ static OWSSignalServiceProtosContent* defaultOWSSignalServiceProtosContentInstan
 - (OWSSignalServiceProtosContentBuilder*) clearSyncMessage {
   resultContent.hasSyncMessage = NO;
   resultContent.syncMessage = [OWSSignalServiceProtosSyncMessage defaultInstance];
+  return self;
+}
+- (BOOL) hasCallMessage {
+  return resultContent.hasCallMessage;
+}
+- (OWSSignalServiceProtosCallMessage*) callMessage {
+  return resultContent.callMessage;
+}
+- (OWSSignalServiceProtosContentBuilder*) setCallMessage:(OWSSignalServiceProtosCallMessage*) value {
+  resultContent.hasCallMessage = YES;
+  resultContent.callMessage = value;
+  return self;
+}
+- (OWSSignalServiceProtosContentBuilder*) setCallMessageBuilder:(OWSSignalServiceProtosCallMessageBuilder*) builderForValue {
+  return [self setCallMessage:[builderForValue build]];
+}
+- (OWSSignalServiceProtosContentBuilder*) mergeCallMessage:(OWSSignalServiceProtosCallMessage*) value {
+  if (resultContent.hasCallMessage &&
+      resultContent.callMessage != [OWSSignalServiceProtosCallMessage defaultInstance]) {
+    resultContent.callMessage =
+      [[[OWSSignalServiceProtosCallMessage builderWithPrototype:resultContent.callMessage] mergeFrom:value] buildPartial];
+  } else {
+    resultContent.callMessage = value;
+  }
+  resultContent.hasCallMessage = YES;
+  return self;
+}
+- (OWSSignalServiceProtosContentBuilder*) clearCallMessage {
+  resultContent.hasCallMessage = NO;
+  resultContent.callMessage = [OWSSignalServiceProtosCallMessage defaultInstance];
+  return self;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessage ()
+@property (strong) OWSSignalServiceProtosCallMessageOffer* offer;
+@property (strong) OWSSignalServiceProtosCallMessageAnswer* answer;
+@property (strong) NSMutableArray<OWSSignalServiceProtosCallMessageIceUpdate*> * iceUpdateArray;
+@property (strong) OWSSignalServiceProtosCallMessageHangup* hangup;
+@property (strong) OWSSignalServiceProtosCallMessageBusy* busy;
+@end
+
+@implementation OWSSignalServiceProtosCallMessage
+
+- (BOOL) hasOffer {
+  return !!hasOffer_;
+}
+- (void) setHasOffer:(BOOL) _value_ {
+  hasOffer_ = !!_value_;
+}
+@synthesize offer;
+- (BOOL) hasAnswer {
+  return !!hasAnswer_;
+}
+- (void) setHasAnswer:(BOOL) _value_ {
+  hasAnswer_ = !!_value_;
+}
+@synthesize answer;
+@synthesize iceUpdateArray;
+@dynamic iceUpdate;
+- (BOOL) hasHangup {
+  return !!hasHangup_;
+}
+- (void) setHasHangup:(BOOL) _value_ {
+  hasHangup_ = !!_value_;
+}
+@synthesize hangup;
+- (BOOL) hasBusy {
+  return !!hasBusy_;
+}
+- (void) setHasBusy:(BOOL) _value_ {
+  hasBusy_ = !!_value_;
+}
+@synthesize busy;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.offer = [OWSSignalServiceProtosCallMessageOffer defaultInstance];
+    self.answer = [OWSSignalServiceProtosCallMessageAnswer defaultInstance];
+    self.hangup = [OWSSignalServiceProtosCallMessageHangup defaultInstance];
+    self.busy = [OWSSignalServiceProtosCallMessageBusy defaultInstance];
+  }
+  return self;
+}
+static OWSSignalServiceProtosCallMessage* defaultOWSSignalServiceProtosCallMessageInstance = nil;
++ (void) initialize {
+  if (self == [OWSSignalServiceProtosCallMessage class]) {
+    defaultOWSSignalServiceProtosCallMessageInstance = [[OWSSignalServiceProtosCallMessage alloc] init];
+  }
+}
++ (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageInstance;
+}
+- (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageInstance;
+}
+- (NSArray<OWSSignalServiceProtosCallMessageIceUpdate*> *)iceUpdate {
+  return iceUpdateArray;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdate*)iceUpdateAtIndex:(NSUInteger)index {
+  return [iceUpdateArray objectAtIndex:index];
+}
+- (BOOL) isInitialized {
+  return YES;
+}
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output {
+  if (self.hasOffer) {
+    [output writeMessage:1 value:self.offer];
+  }
+  if (self.hasAnswer) {
+    [output writeMessage:2 value:self.answer];
+  }
+  [self.iceUpdateArray enumerateObjectsUsingBlock:^(OWSSignalServiceProtosCallMessageIceUpdate *element, NSUInteger idx, BOOL *stop) {
+    [output writeMessage:3 value:element];
+  }];
+  if (self.hasHangup) {
+    [output writeMessage:4 value:self.hangup];
+  }
+  if (self.hasBusy) {
+    [output writeMessage:5 value:self.busy];
+  }
+  [self.unknownFields writeToCodedOutputStream:output];
+}
+- (SInt32) serializedSize {
+  __block SInt32 size_ = memoizedSerializedSize;
+  if (size_ != -1) {
+    return size_;
+  }
+
+  size_ = 0;
+  if (self.hasOffer) {
+    size_ += computeMessageSize(1, self.offer);
+  }
+  if (self.hasAnswer) {
+    size_ += computeMessageSize(2, self.answer);
+  }
+  [self.iceUpdateArray enumerateObjectsUsingBlock:^(OWSSignalServiceProtosCallMessageIceUpdate *element, NSUInteger idx, BOOL *stop) {
+    size_ += computeMessageSize(3, element);
+  }];
+  if (self.hasHangup) {
+    size_ += computeMessageSize(4, self.hangup);
+  }
+  if (self.hasBusy) {
+    size_ += computeMessageSize(5, self.busy);
+  }
+  size_ += self.unknownFields.serializedSize;
+  memoizedSerializedSize = size_;
+  return size_;
+}
++ (OWSSignalServiceProtosCallMessage*) parseFromData:(NSData*) data {
+  return (OWSSignalServiceProtosCallMessage*)[[[OWSSignalServiceProtosCallMessage builder] mergeFromData:data] build];
+}
++ (OWSSignalServiceProtosCallMessage*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessage*)[[[OWSSignalServiceProtosCallMessage builder] mergeFromData:data extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessage*) parseFromInputStream:(NSInputStream*) input {
+  return (OWSSignalServiceProtosCallMessage*)[[[OWSSignalServiceProtosCallMessage builder] mergeFromInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessage*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessage*)[[[OWSSignalServiceProtosCallMessage builder] mergeFromInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessage*) parseFromCodedInputStream:(PBCodedInputStream*) input {
+  return (OWSSignalServiceProtosCallMessage*)[[[OWSSignalServiceProtosCallMessage builder] mergeFromCodedInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessage*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessage*)[[[OWSSignalServiceProtosCallMessage builder] mergeFromCodedInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageBuilder*) builder {
+  return [[OWSSignalServiceProtosCallMessageBuilder alloc] init];
+}
++ (OWSSignalServiceProtosCallMessageBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessage*) prototype {
+  return [[OWSSignalServiceProtosCallMessage builder] mergeFrom:prototype];
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) builder {
+  return [OWSSignalServiceProtosCallMessage builder];
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) toBuilder {
+  return [OWSSignalServiceProtosCallMessage builderWithPrototype:self];
+}
+- (void) writeDescriptionTo:(NSMutableString*) output withIndent:(NSString*) indent {
+  if (self.hasOffer) {
+    [output appendFormat:@"%@%@ {\n", indent, @"offer"];
+    [self.offer writeDescriptionTo:output
+                         withIndent:[NSString stringWithFormat:@"%@  ", indent]];
+    [output appendFormat:@"%@}\n", indent];
+  }
+  if (self.hasAnswer) {
+    [output appendFormat:@"%@%@ {\n", indent, @"answer"];
+    [self.answer writeDescriptionTo:output
+                         withIndent:[NSString stringWithFormat:@"%@  ", indent]];
+    [output appendFormat:@"%@}\n", indent];
+  }
+  [self.iceUpdateArray enumerateObjectsUsingBlock:^(OWSSignalServiceProtosCallMessageIceUpdate *element, NSUInteger idx, BOOL *stop) {
+    [output appendFormat:@"%@%@ {\n", indent, @"iceUpdate"];
+    [element writeDescriptionTo:output
+                     withIndent:[NSString stringWithFormat:@"%@  ", indent]];
+    [output appendFormat:@"%@}\n", indent];
+  }];
+  if (self.hasHangup) {
+    [output appendFormat:@"%@%@ {\n", indent, @"hangup"];
+    [self.hangup writeDescriptionTo:output
+                         withIndent:[NSString stringWithFormat:@"%@  ", indent]];
+    [output appendFormat:@"%@}\n", indent];
+  }
+  if (self.hasBusy) {
+    [output appendFormat:@"%@%@ {\n", indent, @"busy"];
+    [self.busy writeDescriptionTo:output
+                         withIndent:[NSString stringWithFormat:@"%@  ", indent]];
+    [output appendFormat:@"%@}\n", indent];
+  }
+  [self.unknownFields writeDescriptionTo:output withIndent:indent];
+}
+- (void) storeInDictionary:(NSMutableDictionary *)dictionary {
+  if (self.hasOffer) {
+   NSMutableDictionary *messageDictionary = [NSMutableDictionary dictionary]; 
+   [self.offer storeInDictionary:messageDictionary];
+   [dictionary setObject:[NSDictionary dictionaryWithDictionary:messageDictionary] forKey:@"offer"];
+  }
+  if (self.hasAnswer) {
+   NSMutableDictionary *messageDictionary = [NSMutableDictionary dictionary]; 
+   [self.answer storeInDictionary:messageDictionary];
+   [dictionary setObject:[NSDictionary dictionaryWithDictionary:messageDictionary] forKey:@"answer"];
+  }
+  for (OWSSignalServiceProtosCallMessageIceUpdate* element in self.iceUpdateArray) {
+    NSMutableDictionary *elementDictionary = [NSMutableDictionary dictionary];
+    [element storeInDictionary:elementDictionary];
+    [dictionary setObject:[NSDictionary dictionaryWithDictionary:elementDictionary] forKey:@"iceUpdate"];
+  }
+  if (self.hasHangup) {
+   NSMutableDictionary *messageDictionary = [NSMutableDictionary dictionary]; 
+   [self.hangup storeInDictionary:messageDictionary];
+   [dictionary setObject:[NSDictionary dictionaryWithDictionary:messageDictionary] forKey:@"hangup"];
+  }
+  if (self.hasBusy) {
+   NSMutableDictionary *messageDictionary = [NSMutableDictionary dictionary]; 
+   [self.busy storeInDictionary:messageDictionary];
+   [dictionary setObject:[NSDictionary dictionaryWithDictionary:messageDictionary] forKey:@"busy"];
+  }
+  [self.unknownFields storeInDictionary:dictionary];
+}
+- (BOOL) isEqual:(id)other {
+  if (other == self) {
+    return YES;
+  }
+  if (![other isKindOfClass:[OWSSignalServiceProtosCallMessage class]]) {
+    return NO;
+  }
+  OWSSignalServiceProtosCallMessage *otherMessage = other;
+  return
+      self.hasOffer == otherMessage.hasOffer &&
+      (!self.hasOffer || [self.offer isEqual:otherMessage.offer]) &&
+      self.hasAnswer == otherMessage.hasAnswer &&
+      (!self.hasAnswer || [self.answer isEqual:otherMessage.answer]) &&
+      [self.iceUpdateArray isEqualToArray:otherMessage.iceUpdateArray] &&
+      self.hasHangup == otherMessage.hasHangup &&
+      (!self.hasHangup || [self.hangup isEqual:otherMessage.hangup]) &&
+      self.hasBusy == otherMessage.hasBusy &&
+      (!self.hasBusy || [self.busy isEqual:otherMessage.busy]) &&
+      (self.unknownFields == otherMessage.unknownFields || (self.unknownFields != nil && [self.unknownFields isEqual:otherMessage.unknownFields]));
+}
+- (NSUInteger) hash {
+  __block NSUInteger hashCode = 7;
+  if (self.hasOffer) {
+    hashCode = hashCode * 31 + [self.offer hash];
+  }
+  if (self.hasAnswer) {
+    hashCode = hashCode * 31 + [self.answer hash];
+  }
+  [self.iceUpdateArray enumerateObjectsUsingBlock:^(OWSSignalServiceProtosCallMessageIceUpdate *element, NSUInteger idx, BOOL *stop) {
+    hashCode = hashCode * 31 + [element hash];
+  }];
+  if (self.hasHangup) {
+    hashCode = hashCode * 31 + [self.hangup hash];
+  }
+  if (self.hasBusy) {
+    hashCode = hashCode * 31 + [self.busy hash];
+  }
+  hashCode = hashCode * 31 + [self.unknownFields hash];
+  return hashCode;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageOffer ()
+@property UInt64 id;
+@property (strong) NSString* sessionDescription;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageOffer
+
+- (BOOL) hasId {
+  return !!hasId_;
+}
+- (void) setHasId:(BOOL) _value_ {
+  hasId_ = !!_value_;
+}
+@synthesize id;
+- (BOOL) hasSessionDescription {
+  return !!hasSessionDescription_;
+}
+- (void) setHasSessionDescription:(BOOL) _value_ {
+  hasSessionDescription_ = !!_value_;
+}
+@synthesize sessionDescription;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.id = 0L;
+    self.sessionDescription = @"";
+  }
+  return self;
+}
+static OWSSignalServiceProtosCallMessageOffer* defaultOWSSignalServiceProtosCallMessageOfferInstance = nil;
++ (void) initialize {
+  if (self == [OWSSignalServiceProtosCallMessageOffer class]) {
+    defaultOWSSignalServiceProtosCallMessageOfferInstance = [[OWSSignalServiceProtosCallMessageOffer alloc] init];
+  }
+}
++ (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageOfferInstance;
+}
+- (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageOfferInstance;
+}
+- (BOOL) isInitialized {
+  return YES;
+}
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output {
+  if (self.hasId) {
+    [output writeUInt64:1 value:self.id];
+  }
+  if (self.hasSessionDescription) {
+    [output writeString:2 value:self.sessionDescription];
+  }
+  [self.unknownFields writeToCodedOutputStream:output];
+}
+- (SInt32) serializedSize {
+  __block SInt32 size_ = memoizedSerializedSize;
+  if (size_ != -1) {
+    return size_;
+  }
+
+  size_ = 0;
+  if (self.hasId) {
+    size_ += computeUInt64Size(1, self.id);
+  }
+  if (self.hasSessionDescription) {
+    size_ += computeStringSize(2, self.sessionDescription);
+  }
+  size_ += self.unknownFields.serializedSize;
+  memoizedSerializedSize = size_;
+  return size_;
+}
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromData:(NSData*) data {
+  return (OWSSignalServiceProtosCallMessageOffer*)[[[OWSSignalServiceProtosCallMessageOffer builder] mergeFromData:data] build];
+}
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageOffer*)[[[OWSSignalServiceProtosCallMessageOffer builder] mergeFromData:data extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromInputStream:(NSInputStream*) input {
+  return (OWSSignalServiceProtosCallMessageOffer*)[[[OWSSignalServiceProtosCallMessageOffer builder] mergeFromInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageOffer*)[[[OWSSignalServiceProtosCallMessageOffer builder] mergeFromInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromCodedInputStream:(PBCodedInputStream*) input {
+  return (OWSSignalServiceProtosCallMessageOffer*)[[[OWSSignalServiceProtosCallMessageOffer builder] mergeFromCodedInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessageOffer*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageOffer*)[[[OWSSignalServiceProtosCallMessageOffer builder] mergeFromCodedInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageOfferBuilder*) builder {
+  return [[OWSSignalServiceProtosCallMessageOfferBuilder alloc] init];
+}
++ (OWSSignalServiceProtosCallMessageOfferBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessageOffer*) prototype {
+  return [[OWSSignalServiceProtosCallMessageOffer builder] mergeFrom:prototype];
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) builder {
+  return [OWSSignalServiceProtosCallMessageOffer builder];
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) toBuilder {
+  return [OWSSignalServiceProtosCallMessageOffer builderWithPrototype:self];
+}
+- (void) writeDescriptionTo:(NSMutableString*) output withIndent:(NSString*) indent {
+  if (self.hasId) {
+    [output appendFormat:@"%@%@: %@\n", indent, @"id", [NSNumber numberWithLongLong:self.id]];
+  }
+  if (self.hasSessionDescription) {
+    [output appendFormat:@"%@%@: %@\n", indent, @"sessionDescription", self.sessionDescription];
+  }
+  [self.unknownFields writeDescriptionTo:output withIndent:indent];
+}
+- (void) storeInDictionary:(NSMutableDictionary *)dictionary {
+  if (self.hasId) {
+    [dictionary setObject: [NSNumber numberWithLongLong:self.id] forKey: @"id"];
+  }
+  if (self.hasSessionDescription) {
+    [dictionary setObject: self.sessionDescription forKey: @"sessionDescription"];
+  }
+  [self.unknownFields storeInDictionary:dictionary];
+}
+- (BOOL) isEqual:(id)other {
+  if (other == self) {
+    return YES;
+  }
+  if (![other isKindOfClass:[OWSSignalServiceProtosCallMessageOffer class]]) {
+    return NO;
+  }
+  OWSSignalServiceProtosCallMessageOffer *otherMessage = other;
+  return
+      self.hasId == otherMessage.hasId &&
+      (!self.hasId || self.id == otherMessage.id) &&
+      self.hasSessionDescription == otherMessage.hasSessionDescription &&
+      (!self.hasSessionDescription || [self.sessionDescription isEqual:otherMessage.sessionDescription]) &&
+      (self.unknownFields == otherMessage.unknownFields || (self.unknownFields != nil && [self.unknownFields isEqual:otherMessage.unknownFields]));
+}
+- (NSUInteger) hash {
+  __block NSUInteger hashCode = 7;
+  if (self.hasId) {
+    hashCode = hashCode * 31 + [[NSNumber numberWithLongLong:self.id] hash];
+  }
+  if (self.hasSessionDescription) {
+    hashCode = hashCode * 31 + [self.sessionDescription hash];
+  }
+  hashCode = hashCode * 31 + [self.unknownFields hash];
+  return hashCode;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageOfferBuilder()
+@property (strong) OWSSignalServiceProtosCallMessageOffer* resultOffer;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageOfferBuilder
+@synthesize resultOffer;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.resultOffer = [[OWSSignalServiceProtosCallMessageOffer alloc] init];
+  }
+  return self;
+}
+- (PBGeneratedMessage*) internalGetResult {
+  return resultOffer;
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) clear {
+  self.resultOffer = [[OWSSignalServiceProtosCallMessageOffer alloc] init];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) clone {
+  return [OWSSignalServiceProtosCallMessageOffer builderWithPrototype:resultOffer];
+}
+- (OWSSignalServiceProtosCallMessageOffer*) defaultInstance {
+  return [OWSSignalServiceProtosCallMessageOffer defaultInstance];
+}
+- (OWSSignalServiceProtosCallMessageOffer*) build {
+  [self checkInitialized];
+  return [self buildPartial];
+}
+- (OWSSignalServiceProtosCallMessageOffer*) buildPartial {
+  OWSSignalServiceProtosCallMessageOffer* returnMe = resultOffer;
+  self.resultOffer = nil;
+  return returnMe;
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessageOffer*) other {
+  if (other == [OWSSignalServiceProtosCallMessageOffer defaultInstance]) {
+    return self;
+  }
+  if (other.hasId) {
+    [self setId:other.id];
+  }
+  if (other.hasSessionDescription) {
+    [self setSessionDescription:other.sessionDescription];
+  }
+  [self mergeUnknownFields:other.unknownFields];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input {
+  return [self mergeFromCodedInputStream:input extensionRegistry:[PBExtensionRegistry emptyRegistry]];
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  PBUnknownFieldSetBuilder* unknownFields = [PBUnknownFieldSet builderWithUnknownFields:self.unknownFields];
+  while (YES) {
+    SInt32 tag = [input readTag];
+    switch (tag) {
+      case 0:
+        [self setUnknownFields:[unknownFields build]];
+        return self;
+      default: {
+        if (![self parseUnknownField:input unknownFields:unknownFields extensionRegistry:extensionRegistry tag:tag]) {
+          [self setUnknownFields:[unknownFields build]];
+          return self;
+        }
+        break;
+      }
+      case 8: {
+        [self setId:[input readUInt64]];
+        break;
+      }
+      case 18: {
+        [self setSessionDescription:[input readString]];
+        break;
+      }
+    }
+  }
+}
+- (BOOL) hasId {
+  return resultOffer.hasId;
+}
+- (UInt64) id {
+  return resultOffer.id;
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) setId:(UInt64) value {
+  resultOffer.hasId = YES;
+  resultOffer.id = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) clearId {
+  resultOffer.hasId = NO;
+  resultOffer.id = 0L;
+  return self;
+}
+- (BOOL) hasSessionDescription {
+  return resultOffer.hasSessionDescription;
+}
+- (NSString*) sessionDescription {
+  return resultOffer.sessionDescription;
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) setSessionDescription:(NSString*) value {
+  resultOffer.hasSessionDescription = YES;
+  resultOffer.sessionDescription = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageOfferBuilder*) clearSessionDescription {
+  resultOffer.hasSessionDescription = NO;
+  resultOffer.sessionDescription = @"";
+  return self;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageAnswer ()
+@property UInt64 id;
+@property (strong) NSString* sessionDescription;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageAnswer
+
+- (BOOL) hasId {
+  return !!hasId_;
+}
+- (void) setHasId:(BOOL) _value_ {
+  hasId_ = !!_value_;
+}
+@synthesize id;
+- (BOOL) hasSessionDescription {
+  return !!hasSessionDescription_;
+}
+- (void) setHasSessionDescription:(BOOL) _value_ {
+  hasSessionDescription_ = !!_value_;
+}
+@synthesize sessionDescription;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.id = 0L;
+    self.sessionDescription = @"";
+  }
+  return self;
+}
+static OWSSignalServiceProtosCallMessageAnswer* defaultOWSSignalServiceProtosCallMessageAnswerInstance = nil;
++ (void) initialize {
+  if (self == [OWSSignalServiceProtosCallMessageAnswer class]) {
+    defaultOWSSignalServiceProtosCallMessageAnswerInstance = [[OWSSignalServiceProtosCallMessageAnswer alloc] init];
+  }
+}
++ (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageAnswerInstance;
+}
+- (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageAnswerInstance;
+}
+- (BOOL) isInitialized {
+  return YES;
+}
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output {
+  if (self.hasId) {
+    [output writeUInt64:1 value:self.id];
+  }
+  if (self.hasSessionDescription) {
+    [output writeString:2 value:self.sessionDescription];
+  }
+  [self.unknownFields writeToCodedOutputStream:output];
+}
+- (SInt32) serializedSize {
+  __block SInt32 size_ = memoizedSerializedSize;
+  if (size_ != -1) {
+    return size_;
+  }
+
+  size_ = 0;
+  if (self.hasId) {
+    size_ += computeUInt64Size(1, self.id);
+  }
+  if (self.hasSessionDescription) {
+    size_ += computeStringSize(2, self.sessionDescription);
+  }
+  size_ += self.unknownFields.serializedSize;
+  memoizedSerializedSize = size_;
+  return size_;
+}
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromData:(NSData*) data {
+  return (OWSSignalServiceProtosCallMessageAnswer*)[[[OWSSignalServiceProtosCallMessageAnswer builder] mergeFromData:data] build];
+}
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageAnswer*)[[[OWSSignalServiceProtosCallMessageAnswer builder] mergeFromData:data extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromInputStream:(NSInputStream*) input {
+  return (OWSSignalServiceProtosCallMessageAnswer*)[[[OWSSignalServiceProtosCallMessageAnswer builder] mergeFromInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageAnswer*)[[[OWSSignalServiceProtosCallMessageAnswer builder] mergeFromInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromCodedInputStream:(PBCodedInputStream*) input {
+  return (OWSSignalServiceProtosCallMessageAnswer*)[[[OWSSignalServiceProtosCallMessageAnswer builder] mergeFromCodedInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessageAnswer*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageAnswer*)[[[OWSSignalServiceProtosCallMessageAnswer builder] mergeFromCodedInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageAnswerBuilder*) builder {
+  return [[OWSSignalServiceProtosCallMessageAnswerBuilder alloc] init];
+}
++ (OWSSignalServiceProtosCallMessageAnswerBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessageAnswer*) prototype {
+  return [[OWSSignalServiceProtosCallMessageAnswer builder] mergeFrom:prototype];
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) builder {
+  return [OWSSignalServiceProtosCallMessageAnswer builder];
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) toBuilder {
+  return [OWSSignalServiceProtosCallMessageAnswer builderWithPrototype:self];
+}
+- (void) writeDescriptionTo:(NSMutableString*) output withIndent:(NSString*) indent {
+  if (self.hasId) {
+    [output appendFormat:@"%@%@: %@\n", indent, @"id", [NSNumber numberWithLongLong:self.id]];
+  }
+  if (self.hasSessionDescription) {
+    [output appendFormat:@"%@%@: %@\n", indent, @"sessionDescription", self.sessionDescription];
+  }
+  [self.unknownFields writeDescriptionTo:output withIndent:indent];
+}
+- (void) storeInDictionary:(NSMutableDictionary *)dictionary {
+  if (self.hasId) {
+    [dictionary setObject: [NSNumber numberWithLongLong:self.id] forKey: @"id"];
+  }
+  if (self.hasSessionDescription) {
+    [dictionary setObject: self.sessionDescription forKey: @"sessionDescription"];
+  }
+  [self.unknownFields storeInDictionary:dictionary];
+}
+- (BOOL) isEqual:(id)other {
+  if (other == self) {
+    return YES;
+  }
+  if (![other isKindOfClass:[OWSSignalServiceProtosCallMessageAnswer class]]) {
+    return NO;
+  }
+  OWSSignalServiceProtosCallMessageAnswer *otherMessage = other;
+  return
+      self.hasId == otherMessage.hasId &&
+      (!self.hasId || self.id == otherMessage.id) &&
+      self.hasSessionDescription == otherMessage.hasSessionDescription &&
+      (!self.hasSessionDescription || [self.sessionDescription isEqual:otherMessage.sessionDescription]) &&
+      (self.unknownFields == otherMessage.unknownFields || (self.unknownFields != nil && [self.unknownFields isEqual:otherMessage.unknownFields]));
+}
+- (NSUInteger) hash {
+  __block NSUInteger hashCode = 7;
+  if (self.hasId) {
+    hashCode = hashCode * 31 + [[NSNumber numberWithLongLong:self.id] hash];
+  }
+  if (self.hasSessionDescription) {
+    hashCode = hashCode * 31 + [self.sessionDescription hash];
+  }
+  hashCode = hashCode * 31 + [self.unknownFields hash];
+  return hashCode;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageAnswerBuilder()
+@property (strong) OWSSignalServiceProtosCallMessageAnswer* resultAnswer;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageAnswerBuilder
+@synthesize resultAnswer;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.resultAnswer = [[OWSSignalServiceProtosCallMessageAnswer alloc] init];
+  }
+  return self;
+}
+- (PBGeneratedMessage*) internalGetResult {
+  return resultAnswer;
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) clear {
+  self.resultAnswer = [[OWSSignalServiceProtosCallMessageAnswer alloc] init];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) clone {
+  return [OWSSignalServiceProtosCallMessageAnswer builderWithPrototype:resultAnswer];
+}
+- (OWSSignalServiceProtosCallMessageAnswer*) defaultInstance {
+  return [OWSSignalServiceProtosCallMessageAnswer defaultInstance];
+}
+- (OWSSignalServiceProtosCallMessageAnswer*) build {
+  [self checkInitialized];
+  return [self buildPartial];
+}
+- (OWSSignalServiceProtosCallMessageAnswer*) buildPartial {
+  OWSSignalServiceProtosCallMessageAnswer* returnMe = resultAnswer;
+  self.resultAnswer = nil;
+  return returnMe;
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessageAnswer*) other {
+  if (other == [OWSSignalServiceProtosCallMessageAnswer defaultInstance]) {
+    return self;
+  }
+  if (other.hasId) {
+    [self setId:other.id];
+  }
+  if (other.hasSessionDescription) {
+    [self setSessionDescription:other.sessionDescription];
+  }
+  [self mergeUnknownFields:other.unknownFields];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input {
+  return [self mergeFromCodedInputStream:input extensionRegistry:[PBExtensionRegistry emptyRegistry]];
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  PBUnknownFieldSetBuilder* unknownFields = [PBUnknownFieldSet builderWithUnknownFields:self.unknownFields];
+  while (YES) {
+    SInt32 tag = [input readTag];
+    switch (tag) {
+      case 0:
+        [self setUnknownFields:[unknownFields build]];
+        return self;
+      default: {
+        if (![self parseUnknownField:input unknownFields:unknownFields extensionRegistry:extensionRegistry tag:tag]) {
+          [self setUnknownFields:[unknownFields build]];
+          return self;
+        }
+        break;
+      }
+      case 8: {
+        [self setId:[input readUInt64]];
+        break;
+      }
+      case 18: {
+        [self setSessionDescription:[input readString]];
+        break;
+      }
+    }
+  }
+}
+- (BOOL) hasId {
+  return resultAnswer.hasId;
+}
+- (UInt64) id {
+  return resultAnswer.id;
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) setId:(UInt64) value {
+  resultAnswer.hasId = YES;
+  resultAnswer.id = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) clearId {
+  resultAnswer.hasId = NO;
+  resultAnswer.id = 0L;
+  return self;
+}
+- (BOOL) hasSessionDescription {
+  return resultAnswer.hasSessionDescription;
+}
+- (NSString*) sessionDescription {
+  return resultAnswer.sessionDescription;
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) setSessionDescription:(NSString*) value {
+  resultAnswer.hasSessionDescription = YES;
+  resultAnswer.sessionDescription = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageAnswerBuilder*) clearSessionDescription {
+  resultAnswer.hasSessionDescription = NO;
+  resultAnswer.sessionDescription = @"";
+  return self;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageIceUpdate ()
+@property UInt64 id;
+@property (strong) NSString* sdpMid;
+@property UInt32 sdpMlineIndex;
+@property (strong) NSString* sdp;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageIceUpdate
+
+- (BOOL) hasId {
+  return !!hasId_;
+}
+- (void) setHasId:(BOOL) _value_ {
+  hasId_ = !!_value_;
+}
+@synthesize id;
+- (BOOL) hasSdpMid {
+  return !!hasSdpMid_;
+}
+- (void) setHasSdpMid:(BOOL) _value_ {
+  hasSdpMid_ = !!_value_;
+}
+@synthesize sdpMid;
+- (BOOL) hasSdpMlineIndex {
+  return !!hasSdpMlineIndex_;
+}
+- (void) setHasSdpMlineIndex:(BOOL) _value_ {
+  hasSdpMlineIndex_ = !!_value_;
+}
+@synthesize sdpMlineIndex;
+- (BOOL) hasSdp {
+  return !!hasSdp_;
+}
+- (void) setHasSdp:(BOOL) _value_ {
+  hasSdp_ = !!_value_;
+}
+@synthesize sdp;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.id = 0L;
+    self.sdpMid = @"";
+    self.sdpMlineIndex = 0;
+    self.sdp = @"";
+  }
+  return self;
+}
+static OWSSignalServiceProtosCallMessageIceUpdate* defaultOWSSignalServiceProtosCallMessageIceUpdateInstance = nil;
++ (void) initialize {
+  if (self == [OWSSignalServiceProtosCallMessageIceUpdate class]) {
+    defaultOWSSignalServiceProtosCallMessageIceUpdateInstance = [[OWSSignalServiceProtosCallMessageIceUpdate alloc] init];
+  }
+}
++ (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageIceUpdateInstance;
+}
+- (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageIceUpdateInstance;
+}
+- (BOOL) isInitialized {
+  return YES;
+}
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output {
+  if (self.hasId) {
+    [output writeUInt64:1 value:self.id];
+  }
+  if (self.hasSdpMid) {
+    [output writeString:2 value:self.sdpMid];
+  }
+  if (self.hasSdpMlineIndex) {
+    [output writeUInt32:3 value:self.sdpMlineIndex];
+  }
+  if (self.hasSdp) {
+    [output writeString:4 value:self.sdp];
+  }
+  [self.unknownFields writeToCodedOutputStream:output];
+}
+- (SInt32) serializedSize {
+  __block SInt32 size_ = memoizedSerializedSize;
+  if (size_ != -1) {
+    return size_;
+  }
+
+  size_ = 0;
+  if (self.hasId) {
+    size_ += computeUInt64Size(1, self.id);
+  }
+  if (self.hasSdpMid) {
+    size_ += computeStringSize(2, self.sdpMid);
+  }
+  if (self.hasSdpMlineIndex) {
+    size_ += computeUInt32Size(3, self.sdpMlineIndex);
+  }
+  if (self.hasSdp) {
+    size_ += computeStringSize(4, self.sdp);
+  }
+  size_ += self.unknownFields.serializedSize;
+  memoizedSerializedSize = size_;
+  return size_;
+}
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromData:(NSData*) data {
+  return (OWSSignalServiceProtosCallMessageIceUpdate*)[[[OWSSignalServiceProtosCallMessageIceUpdate builder] mergeFromData:data] build];
+}
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageIceUpdate*)[[[OWSSignalServiceProtosCallMessageIceUpdate builder] mergeFromData:data extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromInputStream:(NSInputStream*) input {
+  return (OWSSignalServiceProtosCallMessageIceUpdate*)[[[OWSSignalServiceProtosCallMessageIceUpdate builder] mergeFromInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageIceUpdate*)[[[OWSSignalServiceProtosCallMessageIceUpdate builder] mergeFromInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromCodedInputStream:(PBCodedInputStream*) input {
+  return (OWSSignalServiceProtosCallMessageIceUpdate*)[[[OWSSignalServiceProtosCallMessageIceUpdate builder] mergeFromCodedInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessageIceUpdate*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageIceUpdate*)[[[OWSSignalServiceProtosCallMessageIceUpdate builder] mergeFromCodedInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) builder {
+  return [[OWSSignalServiceProtosCallMessageIceUpdateBuilder alloc] init];
+}
++ (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessageIceUpdate*) prototype {
+  return [[OWSSignalServiceProtosCallMessageIceUpdate builder] mergeFrom:prototype];
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) builder {
+  return [OWSSignalServiceProtosCallMessageIceUpdate builder];
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) toBuilder {
+  return [OWSSignalServiceProtosCallMessageIceUpdate builderWithPrototype:self];
+}
+- (void) writeDescriptionTo:(NSMutableString*) output withIndent:(NSString*) indent {
+  if (self.hasId) {
+    [output appendFormat:@"%@%@: %@\n", indent, @"id", [NSNumber numberWithLongLong:self.id]];
+  }
+  if (self.hasSdpMid) {
+    [output appendFormat:@"%@%@: %@\n", indent, @"sdpMid", self.sdpMid];
+  }
+  if (self.hasSdpMlineIndex) {
+    [output appendFormat:@"%@%@: %@\n", indent, @"sdpMlineIndex", [NSNumber numberWithInteger:self.sdpMlineIndex]];
+  }
+  if (self.hasSdp) {
+    [output appendFormat:@"%@%@: %@\n", indent, @"sdp", self.sdp];
+  }
+  [self.unknownFields writeDescriptionTo:output withIndent:indent];
+}
+- (void) storeInDictionary:(NSMutableDictionary *)dictionary {
+  if (self.hasId) {
+    [dictionary setObject: [NSNumber numberWithLongLong:self.id] forKey: @"id"];
+  }
+  if (self.hasSdpMid) {
+    [dictionary setObject: self.sdpMid forKey: @"sdpMid"];
+  }
+  if (self.hasSdpMlineIndex) {
+    [dictionary setObject: [NSNumber numberWithInteger:self.sdpMlineIndex] forKey: @"sdpMlineIndex"];
+  }
+  if (self.hasSdp) {
+    [dictionary setObject: self.sdp forKey: @"sdp"];
+  }
+  [self.unknownFields storeInDictionary:dictionary];
+}
+- (BOOL) isEqual:(id)other {
+  if (other == self) {
+    return YES;
+  }
+  if (![other isKindOfClass:[OWSSignalServiceProtosCallMessageIceUpdate class]]) {
+    return NO;
+  }
+  OWSSignalServiceProtosCallMessageIceUpdate *otherMessage = other;
+  return
+      self.hasId == otherMessage.hasId &&
+      (!self.hasId || self.id == otherMessage.id) &&
+      self.hasSdpMid == otherMessage.hasSdpMid &&
+      (!self.hasSdpMid || [self.sdpMid isEqual:otherMessage.sdpMid]) &&
+      self.hasSdpMlineIndex == otherMessage.hasSdpMlineIndex &&
+      (!self.hasSdpMlineIndex || self.sdpMlineIndex == otherMessage.sdpMlineIndex) &&
+      self.hasSdp == otherMessage.hasSdp &&
+      (!self.hasSdp || [self.sdp isEqual:otherMessage.sdp]) &&
+      (self.unknownFields == otherMessage.unknownFields || (self.unknownFields != nil && [self.unknownFields isEqual:otherMessage.unknownFields]));
+}
+- (NSUInteger) hash {
+  __block NSUInteger hashCode = 7;
+  if (self.hasId) {
+    hashCode = hashCode * 31 + [[NSNumber numberWithLongLong:self.id] hash];
+  }
+  if (self.hasSdpMid) {
+    hashCode = hashCode * 31 + [self.sdpMid hash];
+  }
+  if (self.hasSdpMlineIndex) {
+    hashCode = hashCode * 31 + [[NSNumber numberWithInteger:self.sdpMlineIndex] hash];
+  }
+  if (self.hasSdp) {
+    hashCode = hashCode * 31 + [self.sdp hash];
+  }
+  hashCode = hashCode * 31 + [self.unknownFields hash];
+  return hashCode;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageIceUpdateBuilder()
+@property (strong) OWSSignalServiceProtosCallMessageIceUpdate* resultIceUpdate;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageIceUpdateBuilder
+@synthesize resultIceUpdate;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.resultIceUpdate = [[OWSSignalServiceProtosCallMessageIceUpdate alloc] init];
+  }
+  return self;
+}
+- (PBGeneratedMessage*) internalGetResult {
+  return resultIceUpdate;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clear {
+  self.resultIceUpdate = [[OWSSignalServiceProtosCallMessageIceUpdate alloc] init];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clone {
+  return [OWSSignalServiceProtosCallMessageIceUpdate builderWithPrototype:resultIceUpdate];
+}
+- (OWSSignalServiceProtosCallMessageIceUpdate*) defaultInstance {
+  return [OWSSignalServiceProtosCallMessageIceUpdate defaultInstance];
+}
+- (OWSSignalServiceProtosCallMessageIceUpdate*) build {
+  [self checkInitialized];
+  return [self buildPartial];
+}
+- (OWSSignalServiceProtosCallMessageIceUpdate*) buildPartial {
+  OWSSignalServiceProtosCallMessageIceUpdate* returnMe = resultIceUpdate;
+  self.resultIceUpdate = nil;
+  return returnMe;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessageIceUpdate*) other {
+  if (other == [OWSSignalServiceProtosCallMessageIceUpdate defaultInstance]) {
+    return self;
+  }
+  if (other.hasId) {
+    [self setId:other.id];
+  }
+  if (other.hasSdpMid) {
+    [self setSdpMid:other.sdpMid];
+  }
+  if (other.hasSdpMlineIndex) {
+    [self setSdpMlineIndex:other.sdpMlineIndex];
+  }
+  if (other.hasSdp) {
+    [self setSdp:other.sdp];
+  }
+  [self mergeUnknownFields:other.unknownFields];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input {
+  return [self mergeFromCodedInputStream:input extensionRegistry:[PBExtensionRegistry emptyRegistry]];
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  PBUnknownFieldSetBuilder* unknownFields = [PBUnknownFieldSet builderWithUnknownFields:self.unknownFields];
+  while (YES) {
+    SInt32 tag = [input readTag];
+    switch (tag) {
+      case 0:
+        [self setUnknownFields:[unknownFields build]];
+        return self;
+      default: {
+        if (![self parseUnknownField:input unknownFields:unknownFields extensionRegistry:extensionRegistry tag:tag]) {
+          [self setUnknownFields:[unknownFields build]];
+          return self;
+        }
+        break;
+      }
+      case 8: {
+        [self setId:[input readUInt64]];
+        break;
+      }
+      case 18: {
+        [self setSdpMid:[input readString]];
+        break;
+      }
+      case 24: {
+        [self setSdpMlineIndex:[input readUInt32]];
+        break;
+      }
+      case 34: {
+        [self setSdp:[input readString]];
+        break;
+      }
+    }
+  }
+}
+- (BOOL) hasId {
+  return resultIceUpdate.hasId;
+}
+- (UInt64) id {
+  return resultIceUpdate.id;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) setId:(UInt64) value {
+  resultIceUpdate.hasId = YES;
+  resultIceUpdate.id = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clearId {
+  resultIceUpdate.hasId = NO;
+  resultIceUpdate.id = 0L;
+  return self;
+}
+- (BOOL) hasSdpMid {
+  return resultIceUpdate.hasSdpMid;
+}
+- (NSString*) sdpMid {
+  return resultIceUpdate.sdpMid;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) setSdpMid:(NSString*) value {
+  resultIceUpdate.hasSdpMid = YES;
+  resultIceUpdate.sdpMid = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clearSdpMid {
+  resultIceUpdate.hasSdpMid = NO;
+  resultIceUpdate.sdpMid = @"";
+  return self;
+}
+- (BOOL) hasSdpMlineIndex {
+  return resultIceUpdate.hasSdpMlineIndex;
+}
+- (UInt32) sdpMlineIndex {
+  return resultIceUpdate.sdpMlineIndex;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) setSdpMlineIndex:(UInt32) value {
+  resultIceUpdate.hasSdpMlineIndex = YES;
+  resultIceUpdate.sdpMlineIndex = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clearSdpMlineIndex {
+  resultIceUpdate.hasSdpMlineIndex = NO;
+  resultIceUpdate.sdpMlineIndex = 0;
+  return self;
+}
+- (BOOL) hasSdp {
+  return resultIceUpdate.hasSdp;
+}
+- (NSString*) sdp {
+  return resultIceUpdate.sdp;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) setSdp:(NSString*) value {
+  resultIceUpdate.hasSdp = YES;
+  resultIceUpdate.sdp = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdateBuilder*) clearSdp {
+  resultIceUpdate.hasSdp = NO;
+  resultIceUpdate.sdp = @"";
+  return self;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageBusy ()
+@property UInt64 id;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageBusy
+
+- (BOOL) hasId {
+  return !!hasId_;
+}
+- (void) setHasId:(BOOL) _value_ {
+  hasId_ = !!_value_;
+}
+@synthesize id;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.id = 0L;
+  }
+  return self;
+}
+static OWSSignalServiceProtosCallMessageBusy* defaultOWSSignalServiceProtosCallMessageBusyInstance = nil;
++ (void) initialize {
+  if (self == [OWSSignalServiceProtosCallMessageBusy class]) {
+    defaultOWSSignalServiceProtosCallMessageBusyInstance = [[OWSSignalServiceProtosCallMessageBusy alloc] init];
+  }
+}
++ (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageBusyInstance;
+}
+- (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageBusyInstance;
+}
+- (BOOL) isInitialized {
+  return YES;
+}
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output {
+  if (self.hasId) {
+    [output writeUInt64:1 value:self.id];
+  }
+  [self.unknownFields writeToCodedOutputStream:output];
+}
+- (SInt32) serializedSize {
+  __block SInt32 size_ = memoizedSerializedSize;
+  if (size_ != -1) {
+    return size_;
+  }
+
+  size_ = 0;
+  if (self.hasId) {
+    size_ += computeUInt64Size(1, self.id);
+  }
+  size_ += self.unknownFields.serializedSize;
+  memoizedSerializedSize = size_;
+  return size_;
+}
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromData:(NSData*) data {
+  return (OWSSignalServiceProtosCallMessageBusy*)[[[OWSSignalServiceProtosCallMessageBusy builder] mergeFromData:data] build];
+}
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageBusy*)[[[OWSSignalServiceProtosCallMessageBusy builder] mergeFromData:data extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromInputStream:(NSInputStream*) input {
+  return (OWSSignalServiceProtosCallMessageBusy*)[[[OWSSignalServiceProtosCallMessageBusy builder] mergeFromInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageBusy*)[[[OWSSignalServiceProtosCallMessageBusy builder] mergeFromInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromCodedInputStream:(PBCodedInputStream*) input {
+  return (OWSSignalServiceProtosCallMessageBusy*)[[[OWSSignalServiceProtosCallMessageBusy builder] mergeFromCodedInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessageBusy*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageBusy*)[[[OWSSignalServiceProtosCallMessageBusy builder] mergeFromCodedInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageBusyBuilder*) builder {
+  return [[OWSSignalServiceProtosCallMessageBusyBuilder alloc] init];
+}
++ (OWSSignalServiceProtosCallMessageBusyBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessageBusy*) prototype {
+  return [[OWSSignalServiceProtosCallMessageBusy builder] mergeFrom:prototype];
+}
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) builder {
+  return [OWSSignalServiceProtosCallMessageBusy builder];
+}
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) toBuilder {
+  return [OWSSignalServiceProtosCallMessageBusy builderWithPrototype:self];
+}
+- (void) writeDescriptionTo:(NSMutableString*) output withIndent:(NSString*) indent {
+  if (self.hasId) {
+    [output appendFormat:@"%@%@: %@\n", indent, @"id", [NSNumber numberWithLongLong:self.id]];
+  }
+  [self.unknownFields writeDescriptionTo:output withIndent:indent];
+}
+- (void) storeInDictionary:(NSMutableDictionary *)dictionary {
+  if (self.hasId) {
+    [dictionary setObject: [NSNumber numberWithLongLong:self.id] forKey: @"id"];
+  }
+  [self.unknownFields storeInDictionary:dictionary];
+}
+- (BOOL) isEqual:(id)other {
+  if (other == self) {
+    return YES;
+  }
+  if (![other isKindOfClass:[OWSSignalServiceProtosCallMessageBusy class]]) {
+    return NO;
+  }
+  OWSSignalServiceProtosCallMessageBusy *otherMessage = other;
+  return
+      self.hasId == otherMessage.hasId &&
+      (!self.hasId || self.id == otherMessage.id) &&
+      (self.unknownFields == otherMessage.unknownFields || (self.unknownFields != nil && [self.unknownFields isEqual:otherMessage.unknownFields]));
+}
+- (NSUInteger) hash {
+  __block NSUInteger hashCode = 7;
+  if (self.hasId) {
+    hashCode = hashCode * 31 + [[NSNumber numberWithLongLong:self.id] hash];
+  }
+  hashCode = hashCode * 31 + [self.unknownFields hash];
+  return hashCode;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageBusyBuilder()
+@property (strong) OWSSignalServiceProtosCallMessageBusy* resultBusy;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageBusyBuilder
+@synthesize resultBusy;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.resultBusy = [[OWSSignalServiceProtosCallMessageBusy alloc] init];
+  }
+  return self;
+}
+- (PBGeneratedMessage*) internalGetResult {
+  return resultBusy;
+}
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) clear {
+  self.resultBusy = [[OWSSignalServiceProtosCallMessageBusy alloc] init];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) clone {
+  return [OWSSignalServiceProtosCallMessageBusy builderWithPrototype:resultBusy];
+}
+- (OWSSignalServiceProtosCallMessageBusy*) defaultInstance {
+  return [OWSSignalServiceProtosCallMessageBusy defaultInstance];
+}
+- (OWSSignalServiceProtosCallMessageBusy*) build {
+  [self checkInitialized];
+  return [self buildPartial];
+}
+- (OWSSignalServiceProtosCallMessageBusy*) buildPartial {
+  OWSSignalServiceProtosCallMessageBusy* returnMe = resultBusy;
+  self.resultBusy = nil;
+  return returnMe;
+}
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessageBusy*) other {
+  if (other == [OWSSignalServiceProtosCallMessageBusy defaultInstance]) {
+    return self;
+  }
+  if (other.hasId) {
+    [self setId:other.id];
+  }
+  [self mergeUnknownFields:other.unknownFields];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input {
+  return [self mergeFromCodedInputStream:input extensionRegistry:[PBExtensionRegistry emptyRegistry]];
+}
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  PBUnknownFieldSetBuilder* unknownFields = [PBUnknownFieldSet builderWithUnknownFields:self.unknownFields];
+  while (YES) {
+    SInt32 tag = [input readTag];
+    switch (tag) {
+      case 0:
+        [self setUnknownFields:[unknownFields build]];
+        return self;
+      default: {
+        if (![self parseUnknownField:input unknownFields:unknownFields extensionRegistry:extensionRegistry tag:tag]) {
+          [self setUnknownFields:[unknownFields build]];
+          return self;
+        }
+        break;
+      }
+      case 8: {
+        [self setId:[input readUInt64]];
+        break;
+      }
+    }
+  }
+}
+- (BOOL) hasId {
+  return resultBusy.hasId;
+}
+- (UInt64) id {
+  return resultBusy.id;
+}
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) setId:(UInt64) value {
+  resultBusy.hasId = YES;
+  resultBusy.id = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBusyBuilder*) clearId {
+  resultBusy.hasId = NO;
+  resultBusy.id = 0L;
+  return self;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageHangup ()
+@property UInt64 id;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageHangup
+
+- (BOOL) hasId {
+  return !!hasId_;
+}
+- (void) setHasId:(BOOL) _value_ {
+  hasId_ = !!_value_;
+}
+@synthesize id;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.id = 0L;
+  }
+  return self;
+}
+static OWSSignalServiceProtosCallMessageHangup* defaultOWSSignalServiceProtosCallMessageHangupInstance = nil;
++ (void) initialize {
+  if (self == [OWSSignalServiceProtosCallMessageHangup class]) {
+    defaultOWSSignalServiceProtosCallMessageHangupInstance = [[OWSSignalServiceProtosCallMessageHangup alloc] init];
+  }
+}
++ (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageHangupInstance;
+}
+- (instancetype) defaultInstance {
+  return defaultOWSSignalServiceProtosCallMessageHangupInstance;
+}
+- (BOOL) isInitialized {
+  return YES;
+}
+- (void) writeToCodedOutputStream:(PBCodedOutputStream*) output {
+  if (self.hasId) {
+    [output writeUInt64:1 value:self.id];
+  }
+  [self.unknownFields writeToCodedOutputStream:output];
+}
+- (SInt32) serializedSize {
+  __block SInt32 size_ = memoizedSerializedSize;
+  if (size_ != -1) {
+    return size_;
+  }
+
+  size_ = 0;
+  if (self.hasId) {
+    size_ += computeUInt64Size(1, self.id);
+  }
+  size_ += self.unknownFields.serializedSize;
+  memoizedSerializedSize = size_;
+  return size_;
+}
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromData:(NSData*) data {
+  return (OWSSignalServiceProtosCallMessageHangup*)[[[OWSSignalServiceProtosCallMessageHangup builder] mergeFromData:data] build];
+}
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromData:(NSData*) data extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageHangup*)[[[OWSSignalServiceProtosCallMessageHangup builder] mergeFromData:data extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromInputStream:(NSInputStream*) input {
+  return (OWSSignalServiceProtosCallMessageHangup*)[[[OWSSignalServiceProtosCallMessageHangup builder] mergeFromInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromInputStream:(NSInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageHangup*)[[[OWSSignalServiceProtosCallMessageHangup builder] mergeFromInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromCodedInputStream:(PBCodedInputStream*) input {
+  return (OWSSignalServiceProtosCallMessageHangup*)[[[OWSSignalServiceProtosCallMessageHangup builder] mergeFromCodedInputStream:input] build];
+}
++ (OWSSignalServiceProtosCallMessageHangup*) parseFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  return (OWSSignalServiceProtosCallMessageHangup*)[[[OWSSignalServiceProtosCallMessageHangup builder] mergeFromCodedInputStream:input extensionRegistry:extensionRegistry] build];
+}
++ (OWSSignalServiceProtosCallMessageHangupBuilder*) builder {
+  return [[OWSSignalServiceProtosCallMessageHangupBuilder alloc] init];
+}
++ (OWSSignalServiceProtosCallMessageHangupBuilder*) builderWithPrototype:(OWSSignalServiceProtosCallMessageHangup*) prototype {
+  return [[OWSSignalServiceProtosCallMessageHangup builder] mergeFrom:prototype];
+}
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) builder {
+  return [OWSSignalServiceProtosCallMessageHangup builder];
+}
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) toBuilder {
+  return [OWSSignalServiceProtosCallMessageHangup builderWithPrototype:self];
+}
+- (void) writeDescriptionTo:(NSMutableString*) output withIndent:(NSString*) indent {
+  if (self.hasId) {
+    [output appendFormat:@"%@%@: %@\n", indent, @"id", [NSNumber numberWithLongLong:self.id]];
+  }
+  [self.unknownFields writeDescriptionTo:output withIndent:indent];
+}
+- (void) storeInDictionary:(NSMutableDictionary *)dictionary {
+  if (self.hasId) {
+    [dictionary setObject: [NSNumber numberWithLongLong:self.id] forKey: @"id"];
+  }
+  [self.unknownFields storeInDictionary:dictionary];
+}
+- (BOOL) isEqual:(id)other {
+  if (other == self) {
+    return YES;
+  }
+  if (![other isKindOfClass:[OWSSignalServiceProtosCallMessageHangup class]]) {
+    return NO;
+  }
+  OWSSignalServiceProtosCallMessageHangup *otherMessage = other;
+  return
+      self.hasId == otherMessage.hasId &&
+      (!self.hasId || self.id == otherMessage.id) &&
+      (self.unknownFields == otherMessage.unknownFields || (self.unknownFields != nil && [self.unknownFields isEqual:otherMessage.unknownFields]));
+}
+- (NSUInteger) hash {
+  __block NSUInteger hashCode = 7;
+  if (self.hasId) {
+    hashCode = hashCode * 31 + [[NSNumber numberWithLongLong:self.id] hash];
+  }
+  hashCode = hashCode * 31 + [self.unknownFields hash];
+  return hashCode;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageHangupBuilder()
+@property (strong) OWSSignalServiceProtosCallMessageHangup* resultHangup;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageHangupBuilder
+@synthesize resultHangup;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.resultHangup = [[OWSSignalServiceProtosCallMessageHangup alloc] init];
+  }
+  return self;
+}
+- (PBGeneratedMessage*) internalGetResult {
+  return resultHangup;
+}
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) clear {
+  self.resultHangup = [[OWSSignalServiceProtosCallMessageHangup alloc] init];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) clone {
+  return [OWSSignalServiceProtosCallMessageHangup builderWithPrototype:resultHangup];
+}
+- (OWSSignalServiceProtosCallMessageHangup*) defaultInstance {
+  return [OWSSignalServiceProtosCallMessageHangup defaultInstance];
+}
+- (OWSSignalServiceProtosCallMessageHangup*) build {
+  [self checkInitialized];
+  return [self buildPartial];
+}
+- (OWSSignalServiceProtosCallMessageHangup*) buildPartial {
+  OWSSignalServiceProtosCallMessageHangup* returnMe = resultHangup;
+  self.resultHangup = nil;
+  return returnMe;
+}
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessageHangup*) other {
+  if (other == [OWSSignalServiceProtosCallMessageHangup defaultInstance]) {
+    return self;
+  }
+  if (other.hasId) {
+    [self setId:other.id];
+  }
+  [self mergeUnknownFields:other.unknownFields];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input {
+  return [self mergeFromCodedInputStream:input extensionRegistry:[PBExtensionRegistry emptyRegistry]];
+}
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  PBUnknownFieldSetBuilder* unknownFields = [PBUnknownFieldSet builderWithUnknownFields:self.unknownFields];
+  while (YES) {
+    SInt32 tag = [input readTag];
+    switch (tag) {
+      case 0:
+        [self setUnknownFields:[unknownFields build]];
+        return self;
+      default: {
+        if (![self parseUnknownField:input unknownFields:unknownFields extensionRegistry:extensionRegistry tag:tag]) {
+          [self setUnknownFields:[unknownFields build]];
+          return self;
+        }
+        break;
+      }
+      case 8: {
+        [self setId:[input readUInt64]];
+        break;
+      }
+    }
+  }
+}
+- (BOOL) hasId {
+  return resultHangup.hasId;
+}
+- (UInt64) id {
+  return resultHangup.id;
+}
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) setId:(UInt64) value {
+  resultHangup.hasId = YES;
+  resultHangup.id = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageHangupBuilder*) clearId {
+  resultHangup.hasId = NO;
+  resultHangup.id = 0L;
+  return self;
+}
+@end
+
+@interface OWSSignalServiceProtosCallMessageBuilder()
+@property (strong) OWSSignalServiceProtosCallMessage* resultCallMessage;
+@end
+
+@implementation OWSSignalServiceProtosCallMessageBuilder
+@synthesize resultCallMessage;
+- (instancetype) init {
+  if ((self = [super init])) {
+    self.resultCallMessage = [[OWSSignalServiceProtosCallMessage alloc] init];
+  }
+  return self;
+}
+- (PBGeneratedMessage*) internalGetResult {
+  return resultCallMessage;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) clear {
+  self.resultCallMessage = [[OWSSignalServiceProtosCallMessage alloc] init];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) clone {
+  return [OWSSignalServiceProtosCallMessage builderWithPrototype:resultCallMessage];
+}
+- (OWSSignalServiceProtosCallMessage*) defaultInstance {
+  return [OWSSignalServiceProtosCallMessage defaultInstance];
+}
+- (OWSSignalServiceProtosCallMessage*) build {
+  [self checkInitialized];
+  return [self buildPartial];
+}
+- (OWSSignalServiceProtosCallMessage*) buildPartial {
+  OWSSignalServiceProtosCallMessage* returnMe = resultCallMessage;
+  self.resultCallMessage = nil;
+  return returnMe;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeFrom:(OWSSignalServiceProtosCallMessage*) other {
+  if (other == [OWSSignalServiceProtosCallMessage defaultInstance]) {
+    return self;
+  }
+  if (other.hasOffer) {
+    [self mergeOffer:other.offer];
+  }
+  if (other.hasAnswer) {
+    [self mergeAnswer:other.answer];
+  }
+  if (other.iceUpdateArray.count > 0) {
+    if (resultCallMessage.iceUpdateArray == nil) {
+      resultCallMessage.iceUpdateArray = [[NSMutableArray alloc] initWithArray:other.iceUpdateArray];
+    } else {
+      [resultCallMessage.iceUpdateArray addObjectsFromArray:other.iceUpdateArray];
+    }
+  }
+  if (other.hasHangup) {
+    [self mergeHangup:other.hangup];
+  }
+  if (other.hasBusy) {
+    [self mergeBusy:other.busy];
+  }
+  [self mergeUnknownFields:other.unknownFields];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input {
+  return [self mergeFromCodedInputStream:input extensionRegistry:[PBExtensionRegistry emptyRegistry]];
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeFromCodedInputStream:(PBCodedInputStream*) input extensionRegistry:(PBExtensionRegistry*) extensionRegistry {
+  PBUnknownFieldSetBuilder* unknownFields = [PBUnknownFieldSet builderWithUnknownFields:self.unknownFields];
+  while (YES) {
+    SInt32 tag = [input readTag];
+    switch (tag) {
+      case 0:
+        [self setUnknownFields:[unknownFields build]];
+        return self;
+      default: {
+        if (![self parseUnknownField:input unknownFields:unknownFields extensionRegistry:extensionRegistry tag:tag]) {
+          [self setUnknownFields:[unknownFields build]];
+          return self;
+        }
+        break;
+      }
+      case 10: {
+        OWSSignalServiceProtosCallMessageOfferBuilder* subBuilder = [OWSSignalServiceProtosCallMessageOffer builder];
+        if (self.hasOffer) {
+          [subBuilder mergeFrom:self.offer];
+        }
+        [input readMessage:subBuilder extensionRegistry:extensionRegistry];
+        [self setOffer:[subBuilder buildPartial]];
+        break;
+      }
+      case 18: {
+        OWSSignalServiceProtosCallMessageAnswerBuilder* subBuilder = [OWSSignalServiceProtosCallMessageAnswer builder];
+        if (self.hasAnswer) {
+          [subBuilder mergeFrom:self.answer];
+        }
+        [input readMessage:subBuilder extensionRegistry:extensionRegistry];
+        [self setAnswer:[subBuilder buildPartial]];
+        break;
+      }
+      case 26: {
+        OWSSignalServiceProtosCallMessageIceUpdateBuilder* subBuilder = [OWSSignalServiceProtosCallMessageIceUpdate builder];
+        [input readMessage:subBuilder extensionRegistry:extensionRegistry];
+        [self addIceUpdate:[subBuilder buildPartial]];
+        break;
+      }
+      case 34: {
+        OWSSignalServiceProtosCallMessageHangupBuilder* subBuilder = [OWSSignalServiceProtosCallMessageHangup builder];
+        if (self.hasHangup) {
+          [subBuilder mergeFrom:self.hangup];
+        }
+        [input readMessage:subBuilder extensionRegistry:extensionRegistry];
+        [self setHangup:[subBuilder buildPartial]];
+        break;
+      }
+      case 42: {
+        OWSSignalServiceProtosCallMessageBusyBuilder* subBuilder = [OWSSignalServiceProtosCallMessageBusy builder];
+        if (self.hasBusy) {
+          [subBuilder mergeFrom:self.busy];
+        }
+        [input readMessage:subBuilder extensionRegistry:extensionRegistry];
+        [self setBusy:[subBuilder buildPartial]];
+        break;
+      }
+    }
+  }
+}
+- (BOOL) hasOffer {
+  return resultCallMessage.hasOffer;
+}
+- (OWSSignalServiceProtosCallMessageOffer*) offer {
+  return resultCallMessage.offer;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) setOffer:(OWSSignalServiceProtosCallMessageOffer*) value {
+  resultCallMessage.hasOffer = YES;
+  resultCallMessage.offer = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) setOfferBuilder:(OWSSignalServiceProtosCallMessageOfferBuilder*) builderForValue {
+  return [self setOffer:[builderForValue build]];
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeOffer:(OWSSignalServiceProtosCallMessageOffer*) value {
+  if (resultCallMessage.hasOffer &&
+      resultCallMessage.offer != [OWSSignalServiceProtosCallMessageOffer defaultInstance]) {
+    resultCallMessage.offer =
+      [[[OWSSignalServiceProtosCallMessageOffer builderWithPrototype:resultCallMessage.offer] mergeFrom:value] buildPartial];
+  } else {
+    resultCallMessage.offer = value;
+  }
+  resultCallMessage.hasOffer = YES;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) clearOffer {
+  resultCallMessage.hasOffer = NO;
+  resultCallMessage.offer = [OWSSignalServiceProtosCallMessageOffer defaultInstance];
+  return self;
+}
+- (BOOL) hasAnswer {
+  return resultCallMessage.hasAnswer;
+}
+- (OWSSignalServiceProtosCallMessageAnswer*) answer {
+  return resultCallMessage.answer;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) setAnswer:(OWSSignalServiceProtosCallMessageAnswer*) value {
+  resultCallMessage.hasAnswer = YES;
+  resultCallMessage.answer = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) setAnswerBuilder:(OWSSignalServiceProtosCallMessageAnswerBuilder*) builderForValue {
+  return [self setAnswer:[builderForValue build]];
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeAnswer:(OWSSignalServiceProtosCallMessageAnswer*) value {
+  if (resultCallMessage.hasAnswer &&
+      resultCallMessage.answer != [OWSSignalServiceProtosCallMessageAnswer defaultInstance]) {
+    resultCallMessage.answer =
+      [[[OWSSignalServiceProtosCallMessageAnswer builderWithPrototype:resultCallMessage.answer] mergeFrom:value] buildPartial];
+  } else {
+    resultCallMessage.answer = value;
+  }
+  resultCallMessage.hasAnswer = YES;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) clearAnswer {
+  resultCallMessage.hasAnswer = NO;
+  resultCallMessage.answer = [OWSSignalServiceProtosCallMessageAnswer defaultInstance];
+  return self;
+}
+- (NSMutableArray<OWSSignalServiceProtosCallMessageIceUpdate*> *)iceUpdate {
+  return resultCallMessage.iceUpdateArray;
+}
+- (OWSSignalServiceProtosCallMessageIceUpdate*)iceUpdateAtIndex:(NSUInteger)index {
+  return [resultCallMessage iceUpdateAtIndex:index];
+}
+- (OWSSignalServiceProtosCallMessageBuilder *)addIceUpdate:(OWSSignalServiceProtosCallMessageIceUpdate*)value {
+  if (resultCallMessage.iceUpdateArray == nil) {
+    resultCallMessage.iceUpdateArray = [[NSMutableArray alloc]init];
+  }
+  [resultCallMessage.iceUpdateArray addObject:value];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder *)setIceUpdateArray:(NSArray<OWSSignalServiceProtosCallMessageIceUpdate*> *)array {
+  resultCallMessage.iceUpdateArray = [[NSMutableArray alloc]initWithArray:array];
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder *)clearIceUpdate {
+  resultCallMessage.iceUpdateArray = nil;
+  return self;
+}
+- (BOOL) hasHangup {
+  return resultCallMessage.hasHangup;
+}
+- (OWSSignalServiceProtosCallMessageHangup*) hangup {
+  return resultCallMessage.hangup;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) setHangup:(OWSSignalServiceProtosCallMessageHangup*) value {
+  resultCallMessage.hasHangup = YES;
+  resultCallMessage.hangup = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) setHangupBuilder:(OWSSignalServiceProtosCallMessageHangupBuilder*) builderForValue {
+  return [self setHangup:[builderForValue build]];
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeHangup:(OWSSignalServiceProtosCallMessageHangup*) value {
+  if (resultCallMessage.hasHangup &&
+      resultCallMessage.hangup != [OWSSignalServiceProtosCallMessageHangup defaultInstance]) {
+    resultCallMessage.hangup =
+      [[[OWSSignalServiceProtosCallMessageHangup builderWithPrototype:resultCallMessage.hangup] mergeFrom:value] buildPartial];
+  } else {
+    resultCallMessage.hangup = value;
+  }
+  resultCallMessage.hasHangup = YES;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) clearHangup {
+  resultCallMessage.hasHangup = NO;
+  resultCallMessage.hangup = [OWSSignalServiceProtosCallMessageHangup defaultInstance];
+  return self;
+}
+- (BOOL) hasBusy {
+  return resultCallMessage.hasBusy;
+}
+- (OWSSignalServiceProtosCallMessageBusy*) busy {
+  return resultCallMessage.busy;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) setBusy:(OWSSignalServiceProtosCallMessageBusy*) value {
+  resultCallMessage.hasBusy = YES;
+  resultCallMessage.busy = value;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) setBusyBuilder:(OWSSignalServiceProtosCallMessageBusyBuilder*) builderForValue {
+  return [self setBusy:[builderForValue build]];
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) mergeBusy:(OWSSignalServiceProtosCallMessageBusy*) value {
+  if (resultCallMessage.hasBusy &&
+      resultCallMessage.busy != [OWSSignalServiceProtosCallMessageBusy defaultInstance]) {
+    resultCallMessage.busy =
+      [[[OWSSignalServiceProtosCallMessageBusy builderWithPrototype:resultCallMessage.busy] mergeFrom:value] buildPartial];
+  } else {
+    resultCallMessage.busy = value;
+  }
+  resultCallMessage.hasBusy = YES;
+  return self;
+}
+- (OWSSignalServiceProtosCallMessageBuilder*) clearBusy {
+  resultCallMessage.hasBusy = NO;
+  resultCallMessage.busy = [OWSSignalServiceProtosCallMessageBusy defaultInstance];
   return self;
 }
 @end

--- a/src/Messages/TSCall.h
+++ b/src/Messages/TSCall.h
@@ -3,6 +3,8 @@
 
 #import "TSInteraction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class TSContactThread;
 
 typedef enum {
@@ -15,9 +17,11 @@ typedef enum {
 
 @property (nonatomic, readonly) RPRecentCallType callType;
 
-- (instancetype)initWithTimestamp:(uint64_t)timeStamp
+- (instancetype)initWithTimestamp:(uint64_t)timestamp
                    withCallNumber:(NSString *)contactNumber
                          callType:(RPRecentCallType)callType
                          inThread:(TSContactThread *)thread;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/TSCall.m
+++ b/src/Messages/TSCall.m
@@ -4,13 +4,16 @@
 #import "TSCall.h"
 #import "TSContactThread.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @implementation TSCall
 
-- (instancetype)initWithTimestamp:(uint64_t)timeStamp
+- (instancetype)initWithTimestamp:(uint64_t)timestamp
                    withCallNumber:(NSString *)contactNumber
                          callType:(RPRecentCallType)callType
-                         inThread:(TSContactThread *)thread {
-    self = [super initWithTimestamp:timeStamp inThread:thread];
+                         inThread:(TSContactThread *)thread
+{
+    self = [super initWithTimestamp:timestamp inThread:thread];
 
     if (self) {
         _callType = callType;
@@ -31,3 +34,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/Messages/TSMessagesManager.h
+++ b/src/Messages/TSMessagesManager.h
@@ -15,12 +15,15 @@ NS_ASSUME_NONNULL_BEGIN
 @class OWSDisappearingMessagesJob;
 @class OWSMessageSender;
 @protocol ContactsManagerProtocol;
+@protocol OWSCallMessageHandler;
 
 @interface TSMessagesManager : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithNetworkManager:(TSNetworkManager *)networkManager
                         storageManager:(TSStorageManager *)storageManager
+                    callMessageHandler:(id<OWSCallMessageHandler>)callMessageHandler
                        contactsManager:(id<ContactsManagerProtocol>)contactsManager
                        contactsUpdater:(ContactsUpdater *)contactsUpdater
                          messageSender:(OWSMessageSender *)messageSender NS_DESIGNATED_INITIALIZER;

--- a/src/Network/API/Requests/OWSTurnServerInfoRequest.h
+++ b/src/Network/API/Requests/OWSTurnServerInfoRequest.h
@@ -1,0 +1,13 @@
+//  Created by Michael Kirk on 11/12/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "TSRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(TurnServerInfoRequest)
+@interface OWSTurnServerInfoRequest : TSRequest
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Network/API/Requests/OWSTurnServerInfoRequest.m
+++ b/src/Network/API/Requests/OWSTurnServerInfoRequest.m
@@ -1,0 +1,26 @@
+//  Created by Michael Kirk on 11/12/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSTurnServerInfoRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+NSString *const OWSTurnServerInfoRequestPath = @"v1/accounts/turn";
+
+@implementation OWSTurnServerInfoRequest
+
+- (instancetype)init
+{
+    self = [super initWithURL:[NSURL URLWithString:OWSTurnServerInfoRequestPath]];
+    if (!self) {
+        return self;
+    }
+
+    [self setHTTPMethod:@"GET"];
+
+    return self;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Network/API/TSNetworkManager.h
+++ b/src/Network/API/TSNetworkManager.h
@@ -28,6 +28,8 @@
 #import <AFNetworking/AFHTTPSessionManager.h>
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface TSNetworkManager : NSObject
 
 + (id)sharedManager;
@@ -37,3 +39,5 @@
             failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure NS_SWIFT_NAME(makeRequest(_:success:failure:));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/Protocols/NotificationsProtocol.h
+++ b/src/Protocols/NotificationsProtocol.h
@@ -1,22 +1,17 @@
-//
-//  NotificationsProtocol.h
-//  Pods
-//
 //  Created by Frederic Jacobs on 05/12/15.
-//
-//
-
-#import <Foundation/Foundation.h>
+//  Copyright © 2015 Open Whisper Systems. All rights reserved.
 
 @class TSErrorMessage;
 @class TSIncomingMessage;
 @class TSThread;
+@protocol ContactsManagerProtocol;
 
 @protocol NotificationsProtocol <NSObject>
 
 - (void)notifyUserForIncomingMessage:(TSIncomingMessage *)incomingMessage
                                 from:(NSString *)name
-                            inThread:(TSThread *)thread;
+                            inThread:(TSThread *)thread
+                     contactsManager:(id<ContactsManagerProtocol>)contactsManager;
 
 - (void)notifyUserForErrorMessage:(TSErrorMessage *)error inThread:(TSThread *)thread;
 

--- a/src/Protocols/OWSCallMessageHandler.h
+++ b/src/Protocols/OWSCallMessageHandler.h
@@ -1,0 +1,27 @@
+//  Created by Michael Kirk on 12/4/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class OWSSignalServiceProtosCallMessageOffer;
+@class OWSSignalServiceProtosCallMessageAnswer;
+@class OWSSignalServiceProtosCallMessageIceUpdate;
+@class OWSSignalServiceProtosCallMessageHangup;
+@class OWSSignalServiceProtosCallMessageBusy;
+
+@protocol OWSCallMessageHandler <NSObject>
+
+- (void)receivedOffer:(OWSSignalServiceProtosCallMessageOffer *)offer
+         fromCallerId:(NSString *)callerId NS_SWIFT_NAME(receivedOffer(_:from:));
+- (void)receivedAnswer:(OWSSignalServiceProtosCallMessageAnswer *)answer
+          fromCallerId:(NSString *)callerId NS_SWIFT_NAME(receivedAnswer(_:from:));
+- (void)receivedIceUpdate:(OWSSignalServiceProtosCallMessageIceUpdate *)iceUpdate
+             fromCallerId:(NSString *)callerId NS_SWIFT_NAME(receivedIceUpdate(_:from:));
+- (void)receivedHangup:(OWSSignalServiceProtosCallMessageHangup *)hangup
+          fromCallerId:(NSString *)callerId NS_SWIFT_NAME(receivedHangup(_:from:));
+- (void)receivedBusy:(OWSSignalServiceProtosCallMessageBusy *)busy
+        fromCallerId:(NSString *)callerId NS_SWIFT_NAME(receivedBusy(_:from:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/TextSecureKitEnv.h
+++ b/src/TextSecureKitEnv.h
@@ -3,19 +3,29 @@
 //  Pods
 //
 //  Created by Frederic Jacobs on 05/12/15.
-//
-//
 
-#import <Foundation/Foundation.h>
+NS_ASSUME_NONNULL_BEGIN
 
-#import "ContactsManagerProtocol.h"
-#import "NotificationsProtocol.h"
+@protocol ContactsManagerProtocol;
+@protocol NotificationsProtocol;
+@protocol OWSCallMessageHandler;
 
 @interface TextSecureKitEnv : NSObject
 
-@property (nonatomic, retain) id<ContactsManagerProtocol> contactsManager;
-@property (nonatomic, retain) id<NotificationsProtocol> notificationsManager;
+- (instancetype)initWithCallMessageHandler:(id<OWSCallMessageHandler>)callMessageHandler
+                           contactsManager:(id<ContactsManagerProtocol>)contactsManager
+                      notificationsManager:(id<NotificationsProtocol>)notificationsManager NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
 
 + (instancetype)sharedEnv;
++ (void)setSharedEnv:(TextSecureKitEnv *)env;
+
+@property (nonatomic, readonly, strong) id<OWSCallMessageHandler> callMessageHandler;
+@property (nonatomic, readonly, strong) id<ContactsManagerProtocol> contactsManager;
+@property (nonatomic, readonly, strong) id<NotificationsProtocol> notificationsManager;
+
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/TextSecureKitEnv.m
+++ b/src/TextSecureKitEnv.m
@@ -1,22 +1,47 @@
-//
-//  TextSecureKitEnv.m
-//  Pods
-//
 //  Created by Frederic Jacobs on 05/12/15.
-//
-//
+//  Copyright © 2015 Open Whisper Systems. All rights reserved.
+
 
 #import "TextSecureKitEnv.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
+static TextSecureKitEnv *TextSecureKitEnvSharedInstance;
+
 @implementation TextSecureKitEnv
 
-+ (instancetype)sharedEnv {
-    static dispatch_once_t onceToken;
-    static id sharedInstance = nil;
-    dispatch_once(&onceToken, ^{
-      sharedInstance = [self.class new];
-    });
-    return sharedInstance;
+@synthesize callMessageHandler = _callMessageHandler;
+@synthesize contactsManager = _contactsManager;
+@synthesize notificationsManager = _notificationsManager;
+
+- (instancetype)initWithCallMessageHandler:(id<OWSCallMessageHandler>)callMessageHandler
+                           contactsManager:(id<ContactsManagerProtocol>)contactsManager
+                      notificationsManager:(id<NotificationsProtocol>)notificationsManager
+{
+    self = [super init];
+    if (!self) {
+        return self;
+    }
+
+    _callMessageHandler = callMessageHandler;
+    _contactsManager = contactsManager;
+    _notificationsManager = notificationsManager;
+
+    return self;
+}
+
++ (instancetype)sharedEnv
+{
+    NSAssert(TextSecureKitEnvSharedInstance, @"Trying to access shared TextSecureKitEnv before it's been set");
+    return TextSecureKitEnvSharedInstance;
+}
+
++ (void)setSharedEnv:(TextSecureKitEnv *)env
+{
+    @synchronized (self) {
+        NSAssert(TextSecureKitEnvSharedInstance == nil, @"Trying to set shared TextSecureKitEnv which has already been set");
+        TextSecureKitEnvSharedInstance = env;
+    }
 }
 
 - (id<ContactsManagerProtocol>)contactsManager {
@@ -26,3 +51,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/Util/OWSError.h
+++ b/src/Util/OWSError.h
@@ -15,6 +15,7 @@ typedef NS_ENUM(NSInteger, OWSErrorCode) {
     OWSErrorCodeFailedToSendOutgoingMessage = 30,
     OWSErrorCodeFailedToDecryptMessage = 100,
     OWSErrorCodeSignalServiceFailure = 1001,
+    OWSErrorCodeSingalServiceRateLimited = 1010,
     OWSErrorCodeUserError = 2001,
 };
 

--- a/src/Util/OWSError.h
+++ b/src/Util/OWSError.h
@@ -23,5 +23,6 @@ extern NSError *OWSErrorWithCodeDescription(OWSErrorCode code, NSString *descrip
 extern NSError *OWSErrorMakeUnableToProcessServerResponseError();
 extern NSError *OWSErrorMakeFailedToSendOutgoingMessageError();
 extern NSError *OWSErrorMakeNoSuchSignalRecipientError();
+extern NSError *OWSErrorMakeAssertionError();
 
 NS_ASSUME_NONNULL_END

--- a/src/Util/OWSError.m
+++ b/src/Util/OWSError.m
@@ -32,4 +32,10 @@ NSError *OWSErrorMakeNoSuchSignalRecipientError()
             @"ERROR_DESCRIPTION_UNREGISTERED_RECIPIENT", @"Error message when attempting to send message"));
 }
 
+NSError *OWSErrorMakeAssertionError()
+{
+    return OWSErrorWithCodeDescription(OWSErrorCodeFailedToSendOutgoingMessage,
+        NSLocalizedString(@"ERROR_DESCRIPTION_UNKNOWN_ERROR", @"Worst case generic error message"));
+}
+
 NS_ASSUME_NONNULL_END

--- a/tests/Devices/OWSReadReceiptTest.m
+++ b/tests/Devices/OWSReadReceiptTest.m
@@ -19,9 +19,10 @@ NS_ASSUME_NONNULL_BEGIN
     // Unfortunately this test will break every time you add, remove, or rename a property, but on the
     // plus side it has a chance of catching when you indadvertently remove our ephemeral properties
     // from our Mantle storage blacklist.
-    NSArray<NSString *> *expected = @[ @"senderId", @"uniqueId", @"timestamp" ];
+    NSSet<NSString *> *expected = [NSSet setWithArray:@[ @"senderId", @"uniqueId", @"timestamp" ]];
+    NSSet<NSString *> *actual = [NSSet setWithArray:[readReceipt.dictionaryValue allKeys]];
 
-    XCTAssertEqualObjects(expected, [readReceipt.dictionaryValue allKeys]);
+    XCTAssertEqualObjects(expected, actual);
 }
 
 @end

--- a/tests/Messages/OWSDisappearingMessageFinderTest.m
+++ b/tests/Messages/OWSDisappearingMessageFinderTest.m
@@ -153,7 +153,7 @@ NS_ASSUME_NONNULL_BEGIN
     XCTAssertNil(self.finder.nextExpirationTimestamp);
 }
 
-- (void)testNextExpirationTimestampNilWithUpcomingExpiringMessages
+- (void)testNextExpirationTimestampNotNilWithUpcomingExpiringMessages
 {
     TSMessage *soonToExpireMessage = [[TSMessage alloc] initWithTimestamp:1
                                                                  inThread:self.thread

--- a/tests/Messages/TSMessagesManagerTest.m
+++ b/tests/Messages/TSMessagesManagerTest.m
@@ -6,6 +6,7 @@
 #import "ContactsManagerProtocol.h"
 #import "ContactsUpdater.h"
 #import "Cryptography.h"
+#import "OWSFakeCallMessageHandler.h"
 #import "OWSFakeContactsManager.h"
 #import "OWSFakeContactsUpdater.h"
 #import "OWSFakeNetworkManager.h"
@@ -73,6 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     return [[TSMessagesManager alloc] initWithNetworkManager:[OWSFakeNetworkManager new]
                                               storageManager:[TSStorageManager sharedManager]
+                                          callMessageHandler:[OWSFakeCallMessageHandler new]
                                              contactsManager:[OWSFakeContactsManager new]
                                              contactsUpdater:[OWSFakeContactsUpdater new]
                                                messageSender:messageSender];

--- a/tests/Storage/TSStorageIdentityKeyStoreTests.m
+++ b/tests/Storage/TSStorageIdentityKeyStoreTests.m
@@ -9,10 +9,12 @@
 #import <XCTest/XCTest.h>
 #import <25519/Curve25519.h>
 
+#import "OWSUnitTestEnvironment.h"
 #import "SecurityUtils.h"
 #import "TSPrivacyPreferences.h"
 #import "TSStorageManager+IdentityKeyStore.h"
 #import "TSStorageManager.h"
+#import "TextSecureKitEnv.h"
 
 @interface TSStorageIdentityKeyStoreTests : XCTestCase
 
@@ -67,7 +69,7 @@
 }
 
 
-- (void)testChangedKeyWIthNonBlockingIdentityChanges
+- (void)testChangedKeyWithNonBlockingIdentityChanges
 {
     TSPrivacyPreferences *preferences = [TSPrivacyPreferences sharedInstance];
     preferences.shouldBlockOnIdentityChange = NO;
@@ -82,6 +84,7 @@
 
     NSData *otherKey = [SecurityUtils generateRandomBytes:32];
 
+    [TextSecureKitEnv setSharedEnv:[OWSUnitTestEnvironment new]];
     XCTAssertTrue([[TSStorageManager sharedManager] isTrustedIdentityKey:otherKey recipientId:recipientId]);
 }
 

--- a/tests/TestSupport/Fakes/OWSFakeCallMessageHandler.h
+++ b/tests/TestSupport/Fakes/OWSFakeCallMessageHandler.h
@@ -1,0 +1,12 @@
+//  Created by Michael Kirk on 12/18/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSCallMessageHandler.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OWSFakeCallMessageHandler : NSObject <OWSCallMessageHandler>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/TestSupport/Fakes/OWSFakeCallMessageHandler.m
+++ b/tests/TestSupport/Fakes/OWSFakeCallMessageHandler.m
@@ -1,0 +1,37 @@
+//  Created by Michael Kirk on 12/18/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSFakeCallMessageHandler.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSFakeCallMessageHandler
+
+- (void)receivedOffer:(OWSSignalServiceProtosCallMessageOffer *)offer fromCallerId:(NSString *)callerId
+{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
+- (void)receivedAnswer:(OWSSignalServiceProtosCallMessageAnswer *)answer fromCallerId:(NSString *)callerId
+{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
+- (void)receivedIceUpdate:(OWSSignalServiceProtosCallMessageIceUpdate *)iceUpdate fromCallerId:(NSString *)callerId
+{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
+- (void)receivedHangup:(OWSSignalServiceProtosCallMessageHangup *)hangup fromCallerId:(NSString *)callerId
+{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
+- (void)receivedBusy:(OWSSignalServiceProtosCallMessageBusy *)busy fromCallerId:(NSString *)callerId
+{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/TestSupport/Fakes/OWSFakeNotificationsManager.h
+++ b/tests/TestSupport/Fakes/OWSFakeNotificationsManager.h
@@ -1,0 +1,12 @@
+//  Created by Michael Kirk on 12/18/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "NotificationsProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OWSFakeNotificationsManager : NSObject <NotificationsProtocol>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/TestSupport/Fakes/OWSFakeNotificationsManager.m
+++ b/tests/TestSupport/Fakes/OWSFakeNotificationsManager.m
@@ -1,0 +1,25 @@
+//  Created by Michael Kirk on 12/18/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSFakeNotificationsManager.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSFakeNotificationsManager
+
+- (void)notifyUserForIncomingMessage:(TSIncomingMessage *)incomingMessage
+                                from:(NSString *)name
+                            inThread:(TSThread *)thread
+{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
+- (void)notifyUserForErrorMessage:(TSErrorMessage *)error inThread:(TSThread *)thread
+{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/TestSupport/Fakes/OWSUnitTestEnvironment.h
+++ b/tests/TestSupport/Fakes/OWSUnitTestEnvironment.h
@@ -1,0 +1,14 @@
+//  Created by Michael Kirk on 12/18/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "TextSecureKitEnv.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OWSUnitTestEnvironment : TextSecureKitEnv
+
+- (instancetype)initDefault;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/TestSupport/Fakes/OWSUnitTestEnvironment.m
+++ b/tests/TestSupport/Fakes/OWSUnitTestEnvironment.m
@@ -1,0 +1,22 @@
+//  Created by Michael Kirk on 12/18/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+
+#import "OWSUnitTestEnvironment.h"
+#import "OWSFakeCallMessageHandler.h"
+#import "OWSFakeContactsManager.h"
+#import "OWSFakeNotificationsManager.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSUnitTestEnvironment
+
+- (instancetype)init
+{
+    return [super initWithCallMessageHandler:[OWSFakeCallMessageHandler new]
+                             contactsManager:[OWSFakeContactsManager new]
+                        notificationsManager:[OWSFakeNotificationsManager new]];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Not sure if you'll approve of this, since will clean up entire files, not just areas already touched. But we have a lot of trailing space in our files.  It seems to arise from a difference between XCode's auto format and clang-format's style, and clang-format doesn't seem to clean this. Thoughts?

PTAL @michaelkirk 

