### PR TITLE
Add WebRTC setting.

### DIFF
--- a/src/Account/TSAccountManager.h
+++ b/src/Account/TSAccountManager.h
@@ -64,6 +64,7 @@ static NSString *const TSRegistrationErrorUserInfoHTTPStatus = @"TSHTTPStatus";
 + (void)rerequestVoiceWithSuccess:(void (^)())successBlock failure:(void (^)(NSError *error))failureBlock;
 
 - (void)verifyAccountWithCode:(NSString *)verificationCode
+              isWebRTCEnabled:(BOOL)isWebRTCEnabled
                       success:(void (^)())successBlock
                       failure:(void (^)(NSError *error))failureBlock;
 

--- a/src/Account/TSAccountManager.m
+++ b/src/Account/TSAccountManager.m
@@ -181,6 +181,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)verifyAccountWithCode:(NSString *)verificationCode
+              isWebRTCEnabled:(BOOL)isWebRTCEnabled
                       success:(void (^)())successBlock
                       failure:(void (^)(NSError *error))failureBlock
 {
@@ -195,7 +196,8 @@ NS_ASSUME_NONNULL_BEGIN
     TSVerifyCodeRequest *request = [[TSVerifyCodeRequest alloc] initWithVerificationCode:verificationCode
                                                                                forNumber:phoneNumber
                                                                             signalingKey:signalingKey
-                                                                                 authKey:authToken];
+                                                                                 authKey:authToken
+                                                                         isWebRTCEnabled:isWebRTCEnabled];
 
     [self.networkManager makeRequest:request
         success:^(NSURLSessionDataTask *task, id responseObject) {

--- a/src/Account/TSAttributes.h
+++ b/src/Account/TSAttributes.h
@@ -10,9 +10,10 @@
 
 @interface TSAttributes : NSObject
 
-+ (NSDictionary *)attributesFromStorageWithVoiceSupport;
++ (NSDictionary *)attributesFromStorage:(BOOL)isWebRTCEnabled;
 
 + (NSDictionary *)attributesWithSignalingKey:(NSString *)signalingKey
-                             serverAuthToken:(NSString *)authToken;
+                             serverAuthToken:(NSString *)authToken
+                             isWebRTCEnabled:(BOOL)isWebRTCEnabled;
 
 @end

--- a/src/Account/TSAttributes.m
+++ b/src/Account/TSAttributes.m
@@ -13,18 +13,21 @@
 
 @implementation TSAttributes
 
-+ (NSDictionary *)attributesFromStorageWithVoiceSupport {
++ (NSDictionary *)attributesFromStorage:(BOOL)isWebRTCEnabled {
     return [self attributesWithSignalingKey:[TSStorageManager signalingKey]
-                            serverAuthToken:[TSStorageManager serverAuthToken]];
+                            serverAuthToken:[TSStorageManager serverAuthToken]
+                            isWebRTCEnabled:isWebRTCEnabled];
 }
 
 + (NSDictionary *)attributesWithSignalingKey:(NSString *)signalingKey
                              serverAuthToken:(NSString *)authToken
+                             isWebRTCEnabled:(BOOL)isWebRTCEnabled
 {
     return @{
         @"signalingKey" : signalingKey,
         @"AuthKey" : authToken,
-        @"voice" : [NSNumber numberWithBool:YES], // all Signal-iOS clients support voice
+        @"voice" : @(YES), // all Signal-iOS clients support voice
+        @"video" : @(isWebRTCEnabled),
         @"registrationId" : [NSString stringWithFormat:@"%i", [TSAccountManager getOrGenerateRegistrationId]]
     };
 }

--- a/src/Network/API/Requests/TSUpdateAttributesRequest.h
+++ b/src/Network/API/Requests/TSUpdateAttributesRequest.h
@@ -10,6 +10,6 @@
 
 @interface TSUpdateAttributesRequest : TSRequest
 
-- (instancetype)initWithUpdatedAttributesWithVoice;
+- (instancetype)initWithUpdatedAttributes:(BOOL)isWebRTCEnabled;
 
 @end

--- a/src/Network/API/Requests/TSUpdateAttributesRequest.m
+++ b/src/Network/API/Requests/TSUpdateAttributesRequest.m
@@ -12,13 +12,13 @@
 
 @implementation TSUpdateAttributesRequest
 
-- (instancetype)initWithUpdatedAttributesWithVoice {
+- (instancetype)initWithUpdatedAttributes:(BOOL)isWebRTCEnabled {
     NSString *endPoint = [textSecureAccountsAPI stringByAppendingString:textSecureAttributesAPI];
     self               = [super initWithURL:[NSURL URLWithString:endPoint]];
 
     if (self) {
         [self setHTTPMethod:@"PUT"];
-        [self.parameters addEntriesFromDictionary:[TSAttributes attributesFromStorageWithVoiceSupport]];
+        [self.parameters addEntriesFromDictionary:[TSAttributes attributesFromStorage:isWebRTCEnabled]];
     }
 
     return self;

--- a/src/Network/API/Requests/TSVerifyCodeRequest.h
+++ b/src/Network/API/Requests/TSVerifyCodeRequest.h
@@ -13,7 +13,8 @@
 - (TSRequest *)initWithVerificationCode:(NSString *)verificationCode
                               forNumber:(NSString *)phoneNumber
                            signalingKey:(NSString *)signalingKey
-                                authKey:(NSString *)authKey;
+                                authKey:(NSString *)authKey
+                        isWebRTCEnabled:(BOOL)isWebRTCEnabled;
 
 @property (nonatomic, readonly) NSString *numberToValidate;
 

--- a/src/Network/API/Requests/TSVerifyCodeRequest.m
+++ b/src/Network/API/Requests/TSVerifyCodeRequest.m
@@ -16,13 +16,16 @@
 - (TSRequest *)initWithVerificationCode:(NSString *)verificationCode
                               forNumber:(NSString *)phoneNumber
                            signalingKey:(NSString *)signalingKey
-                                authKey:(NSString *)authKey {
+                                authKey:(NSString *)authKey
+                        isWebRTCEnabled:(BOOL)isWebRTCEnabled {
     self = [super
         initWithURL:[NSURL URLWithString:[NSString
                                              stringWithFormat:@"%@/code/%@", textSecureAccountsAPI, verificationCode]]];
 
     NSDictionary *attributes =
-        [TSAttributes attributesWithSignalingKey:signalingKey serverAuthToken:authKey];
+        [TSAttributes attributesWithSignalingKey:signalingKey
+                                 serverAuthToken:authKey
+                                 isWebRTCEnabled:isWebRTCEnabled];
 
     _numberToValidate = phoneNumber;
     [self.parameters addEntriesFromDictionary:attributes];


### PR DESCRIPTION
Adds a preference that enables WebRTC-based calling.  In terms of SSK, this involves adding a property to the "update attributes". During the beta period, when this preference can be changed by the user, we'll need to plumb it through our SSK request logic.  That's this PR.  Later, we'l be able to revert much of this work and use a hard-coded value.

PTAL @michaelkirk 