### PR TITLE
Add disappearing message time of 10 minutes

### DIFF
--- a/src/Contacts/OWSDisappearingMessagesConfiguration.m
+++ b/src/Contacts/OWSDisappearingMessagesConfiguration.m
@@ -133,6 +133,7 @@ const uint32_t OWSDisappearingMessagesConfigurationDefaultExpirationDuration = 6
               @(30),
               @(60),
               @(300),
+              @(600),
               @(1800),
               @(3600),
               @(21600),


### PR DESCRIPTION
This adds 10 minutes to the selectable times for disappearing messages,
making the minutes' values match the seconds' and make the list feel
more complete.