### PR TITLE
Remove Cuba from domain fronting.

### DIFF
--- a/src/Network/OWSCensorshipConfiguration.m
+++ b/src/Network/OWSCensorshipConfiguration.m
@@ -1,5 +1,6 @@
-// Created by Michael Kirk on 12/20/16.
-// Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "OWSCensorshipConfiguration.h"
 #import "TSStorageManager.h"
@@ -52,8 +53,6 @@ NSString *const OWSCensorshipConfigurationReflectorHost = @"signal-reflector-mee
     return @{
              // Egypt
              @"+20": @"google.com.eg",
-             // Cuba
-             @"+53": @"google.com.cu",
              // Oman
              @"+968": @"google.com.om",
              // UAE


### PR DESCRIPTION
Google hosted domain fronting doesn't work in Cuba due to export
restrictions. OTOH there are reports of Signal working just fine without
domain fronting in Cuba.

// FREEBIE