### PR TITLE
dont reset storage before first unlock

### DIFF
--- a/src/Storage/TSStorageManager.h
+++ b/src/Storage/TSStorageManager.h
@@ -1,9 +1,5 @@
 //
-//  TSStorageManager.h
-//  TextSecureKit
-//
-//  Created by Frederic Jacobs on 27/10/14.
-//  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
 #import "TSStorageKeys.h"
@@ -21,9 +17,17 @@ extern NSString *const TSUIDatabaseConnectionDidUpdateNotification;
 @interface TSStorageManager : NSObject
 
 + (instancetype)sharedManager;
+
+/**
+ * Returns NO if:
+ *
+ * - Keychain is locked because device has just been restarted.
+ * - Password could not be retrieved because of a keychain error.
+ */
++ (BOOL)isDatabasePasswordAccessible;
+
 - (void)setupDatabase;
 - (void)deleteThreadsAndMessages;
-- (BOOL)databasePasswordAccessible;
 - (void)resetSignalStorage;
 
 - (YapDatabase *)database;

--- a/src/Storage/TSStorageManager.m
+++ b/src/Storage/TSStorageManager.m
@@ -1,6 +1,4 @@
 //
-//  TSStorageManager.m
-//
 //  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
@@ -23,7 +21,8 @@
 NSString *const TSUIDatabaseConnectionDidUpdateNotification = @"TSUIDatabaseConnectionDidUpdateNotification";
 
 NSString *const TSStorageManagerExceptionNameDatabasePasswordInaccessible = @"TSStorageManagerExceptionNameDatabasePasswordInaccessible";
-NSString *const TSStorageManagerExceptionNameDatabasePasswordInaccessibleWhileBackgrounded = @"TSStorageManagerExceptionNameDatabasePasswordInaccessibleWhileBackgrounded";
+NSString *const TSStorageManagerExceptionNameDatabasePasswordInaccessibleWhileBackgrounded =
+    @"TSStorageManagerExceptionNameDatabasePasswordInaccessibleWhileBackgrounded";
 NSString *const TSStorageManagerExceptionNameDatabasePasswordUnwritable = @"TSStorageManagerExceptionNameDatabasePasswordUnwritable";
 NSString *const TSStorageManagerExceptionNameNoDatabase = @"TSStorageManagerExceptionNameNoDatabase";
 
@@ -271,7 +270,7 @@ static NSString *keychainDBPassAccount    = @"TSDatabasePass";
     return databasePath;
 }
 
-- (BOOL)databasePasswordAccessible
++ (BOOL)isDatabasePasswordAccessible
 {
     [SAMKeychain setAccessibilityType:kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly];
     NSError *error;


### PR DESCRIPTION
Prevent destroying user database after restarting device, by not taking any drastic measures (like resetting the user's storage) when the app is running in the background.

If there's really a problem, it will manifest in the foreground, while in the background it's very likely the user just hasn't unlocked their device since restart.

corresponding Signal-iOS: https://github.com/WhisperSystems/Signal-iOS/pull/1636

PTAL @charlesmchen 