### PR TITLE
Rework concurrency in the signaling logic.

### DIFF
--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -436,7 +436,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
         }
 
         if ([exception.name isEqualToString:OWSMessageSenderRateLimitedException]) {
-            NSError *error = OWSErrorWithCodeDescription(OWSErrorCodeSingalServiceRateLimited,
+            NSError *error = OWSErrorWithCodeDescription(OWSErrorCodeSignalServiceRateLimited,
                 NSLocalizedString(@"FAILED_SENDING_BECAUSE_RATE_LIMIT",
                     @"action sheet header when re-sending message which failed because of too many attempts"));
             return failureHandler(error);

--- a/src/Util/OWSError.h
+++ b/src/Util/OWSError.h
@@ -18,7 +18,8 @@ typedef NS_ENUM(NSInteger, OWSErrorCode) {
     OWSErrorCodeFailedToDecryptMessage = 100,
     OWSErrorCodeFailedToEncryptMessage = 110,
     OWSErrorCodeSignalServiceFailure = 1001,
-    OWSErrorCodeSingalServiceRateLimited = 1010,
+    OWSErrorCodeSignalServiceRateLimited = 1010,
+    OWSErrorCodeWebRTCMissingDataChannel = 1011,
     OWSErrorCodeUserError = 2001,
 };
 
@@ -27,5 +28,6 @@ extern NSError *OWSErrorMakeUnableToProcessServerResponseError();
 extern NSError *OWSErrorMakeFailedToSendOutgoingMessageError();
 extern NSError *OWSErrorMakeNoSuchSignalRecipientError();
 extern NSError *OWSErrorMakeAssertionError();
+extern NSError *OWSErrorMakeWebRTCMissingDataChannelError();
 
 NS_ASSUME_NONNULL_END

--- a/src/Util/OWSError.h
+++ b/src/Util/OWSError.h
@@ -19,7 +19,6 @@ typedef NS_ENUM(NSInteger, OWSErrorCode) {
     OWSErrorCodeFailedToEncryptMessage = 110,
     OWSErrorCodeSignalServiceFailure = 1001,
     OWSErrorCodeSignalServiceRateLimited = 1010,
-    OWSErrorCodeWebRTCMissingDataChannel = 1011,
     OWSErrorCodeUserError = 2001,
 };
 
@@ -28,6 +27,5 @@ extern NSError *OWSErrorMakeUnableToProcessServerResponseError();
 extern NSError *OWSErrorMakeFailedToSendOutgoingMessageError();
 extern NSError *OWSErrorMakeNoSuchSignalRecipientError();
 extern NSError *OWSErrorMakeAssertionError();
-extern NSError *OWSErrorMakeWebRTCMissingDataChannelError();
 
 NS_ASSUME_NONNULL_END

--- a/src/Util/OWSError.m
+++ b/src/Util/OWSError.m
@@ -1,4 +1,6 @@
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "OWSError.h"
 
@@ -35,7 +37,13 @@ NSError *OWSErrorMakeNoSuchSignalRecipientError()
 NSError *OWSErrorMakeAssertionError()
 {
     return OWSErrorWithCodeDescription(OWSErrorCodeFailedToSendOutgoingMessage,
-        NSLocalizedString(@"ERROR_DESCRIPTION_UNKNOWN_ERROR", @"Worst case generic error message"));
+                                       NSLocalizedString(@"ERROR_DESCRIPTION_UNKNOWN_ERROR", @"Worst case generic error message"));
+}
+
+NSError *OWSErrorMakeWebRTCMissingDataChannelError()
+{
+    return OWSErrorWithCodeDescription(OWSErrorCodeWebRTCMissingDataChannel,
+                                       NSLocalizedString(@"ERROR_DESCRIPTION_WEBRTC_MISSING_DATA_CHANNEL", @"Missing data channel while trying to sending message"));
 }
 
 NS_ASSUME_NONNULL_END

--- a/src/Util/OWSError.m
+++ b/src/Util/OWSError.m
@@ -40,10 +40,4 @@ NSError *OWSErrorMakeAssertionError()
                                        NSLocalizedString(@"ERROR_DESCRIPTION_UNKNOWN_ERROR", @"Worst case generic error message"));
 }
 
-NSError *OWSErrorMakeWebRTCMissingDataChannelError()
-{
-    return OWSErrorWithCodeDescription(OWSErrorCodeWebRTCMissingDataChannel,
-                                       NSLocalizedString(@"ERROR_DESCRIPTION_WEBRTC_MISSING_DATA_CHANNEL", @"Missing data channel while trying to sending message"));
-}
-
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Adds an error, fixes a typo.

PTAL @michaelkirk 