### PR TITLE
Automatically mark as read any messages sent by current user from ano…

### DIFF
--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -635,11 +635,10 @@ NS_ASSUME_NONNULL_BEGIN
 
           // Any messages sent from the current user - from this device or another - should be
           // automatically marked as read.
-          if ([TSAccountManager isRegistered]) {
-              BOOL shouldMarkMessageAsRead = [envelope.source isEqualToString:[TSAccountManager localNumber]];
-              if (shouldMarkMessageAsRead) {
-                  [incomingMessage markAsReadLocallyWithTransaction:transaction];
-              }
+          OWSAssert([TSAccountManager isRegistered]);
+          BOOL shouldMarkMessageAsRead = [envelope.source isEqualToString:[TSAccountManager localNumber]];
+          if (shouldMarkMessageAsRead) {
+              [incomingMessage markAsReadLocallyWithTransaction:transaction];
           }
 
           // Android allows attachments to be sent with body.

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -633,6 +633,15 @@ NS_ASSUME_NONNULL_BEGIN
       if (thread && incomingMessage) {
           [incomingMessage saveWithTransaction:transaction];
 
+          // Any messages sent from the current user - from this device or another - should be
+          // automatically marked as read.
+          if ([TSAccountManager isRegistered]) {
+              BOOL shouldMarkMessageAsRead = [envelope.source isEqualToString:[TSAccountManager localNumber]];
+              if (shouldMarkMessageAsRead) {
+                  [incomingMessage markAsReadLocallyWithTransaction:transaction];
+              }
+          }
+
           // Android allows attachments to be sent with body.
           if ([attachmentIds count] > 0 && body != nil && ![body isEqualToString:@""]) {
               // We want the text to be displayed under the attachment


### PR DESCRIPTION
…ther device.

Repro:

* Conduct a conversation between device A and desktop linked with device B.
* Read conversation on device B.

Expected: only "unread" messages from A are marked as unread.
Observed: messages sent from desktop linked with B show up as unread on B.

PTAL @michaelkirk 
