### PR TITLE
Order messages by "sent" timestamp, not "received" timestamp.

### DIFF
--- a/src/Storage/TSDatabaseView.m
+++ b/src/Storage/TSDatabaseView.m
@@ -268,15 +268,6 @@ NSString *TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevicesData
 
 + (NSDate *)localTimeReceiveDateForInteraction:(TSInteraction *)interaction {
     NSDate *interactionDate = interaction.date;
-
-    if ([interaction isKindOfClass:[TSIncomingMessage class]]) {
-        TSIncomingMessage *message = (TSIncomingMessage *)interaction;
-
-        if (message.receivedAt) {
-            interactionDate = message.receivedAt;
-        }
-    }
-
     return interactionDate;
 }
 


### PR DESCRIPTION
I'm not sure why, but we were ordering messages by "received" timestamp, not "sent" timestamp. This scrambles the ordering of conversations. 

Repro:

* Conduct a conversation between device A and desktop linked with device B.
* Read conversation on device B.  

Expected: Messages sent in order "alice, bob, carol, david"... will show up in same order.
Observed: Messages will be sent grouped by sender, since we fetch incoming and outgoing messages separately.

![order-by-received](https://cloud.githubusercontent.com/assets/625803/22620578/c90f0ebe-eadc-11e6-8f5f-a05dce26ab39.png)
![order-by-sent](https://cloud.githubusercontent.com/assets/625803/22620577/c90d4458-eadc-11e6-9414-91b1805b2ddc.png)

PTAL @michaelkirk 