### PR TITLE
Avoid deadlock when marking self-sent messages as read.

### DIFF
--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -560,6 +560,10 @@ NS_ASSUME_NONNULL_BEGIN
     __block TSIncomingMessage *_Nullable incomingMessage;
     __block TSThread *thread;
 
+    // Do this outside of a transaction to avoid deadlock
+    OWSAssert([TSAccountManager isRegistered]);
+    NSString *localNumber = [TSAccountManager localNumber];
+
     [self.dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
       if (groupId) {
           NSMutableArray *uniqueMemberIds = [[[NSSet setWithArray:dataMessage.group.members] allObjects] mutableCopy];
@@ -634,8 +638,7 @@ NS_ASSUME_NONNULL_BEGIN
 
           // Any messages sent from the current user - from this device or another - should be
           // automatically marked as read.
-          OWSAssert([TSAccountManager isRegistered]);
-          BOOL shouldMarkMessageAsRead = [envelope.source isEqualToString:[TSAccountManager localNumber]];
+          BOOL shouldMarkMessageAsRead = [envelope.source isEqualToString:localNumber];
           if (shouldMarkMessageAsRead) {
               [incomingMessage markAsReadLocallyWithTransaction:transaction];
           }


### PR DESCRIPTION
Fetching the localNumber invokes another transaction, which can
result in deadlock if called during an existing transaction.

PTAL @charlesmchen 

I've been bitten by similar versions of this bug many times. There are broadly two approaches I see to avoiding it, both with their shortcomings...

1. Prefer methods that take a transaction as a parameter (this can lead to some really verbose code)
2. Make your transactions smaller (this can sometimes cause inconsistent state)