### PR TITLE
Add disappearing message time of 3 weeks

### DIFF
--- a/src/Contacts/OWSDisappearingMessagesConfiguration.m
+++ b/src/Contacts/OWSDisappearingMessagesConfiguration.m
@@ -138,7 +138,8 @@ const uint32_t OWSDisappearingMessagesConfigurationDefaultExpirationDuration = 6
               @(21600),
               @(43200),
               @(86400),
-              @(604800) ];
+              @(604800),
+              @(1814400) ];
 }
 
 - (NSUInteger)durationIndex


### PR DESCRIPTION
This adds 3 weeks to the selectable times for disappearing messages.
1 week maximum is too short for certain uses.

This is the equivalent of  [WhisperSystems/Signal-Android#6197](https://github.com/WhisperSystems/Signal-Android/pull/6197)`
and [WhisperSystems/Signal-Desktop#1058](https://github.com/WhisperSystems/Signal-Desktop/pull/1058)