### PR TITLE
Add “received at” timestamp to all TSMessages so that they may be sor…

### DIFF
--- a/src/Contacts/TSThread.m
+++ b/src/Contacts/TSThread.m
@@ -248,9 +248,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateWithLastMessage:(TSInteraction *)lastMessage transaction:(YapDatabaseReadWriteTransaction *)transaction {
     NSDate *lastMessageDate = lastMessage.date;
 
-    if ([lastMessage isKindOfClass:[TSIncomingMessage class]]) {
-        TSIncomingMessage *message = (TSIncomingMessage *)lastMessage;
-        lastMessageDate            = message.receivedAt;
+    if ([lastMessage isKindOfClass:[TSMessage class]]) {
+        TSMessage *message = (TSMessage *)lastMessage;
+        if ([message bestReceivedAtDate]) {
+            lastMessageDate = [message bestReceivedAtDate];
+        }
     }
 
     if (!_lastMessageDate || [lastMessageDate timeIntervalSinceDate:self.lastMessageDate] > 0) {

--- a/src/Contacts/TSThread.m
+++ b/src/Contacts/TSThread.m
@@ -246,14 +246,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)updateWithLastMessage:(TSInteraction *)lastMessage transaction:(YapDatabaseReadWriteTransaction *)transaction {
-    NSDate *lastMessageDate = lastMessage.date;
-
-    if ([lastMessage isKindOfClass:[TSMessage class]]) {
-        TSMessage *message = (TSMessage *)lastMessage;
-        if ([message bestReceivedAtDate]) {
-            lastMessageDate = [message bestReceivedAtDate];
-        }
-    }
+    NSDate *lastMessageDate = [lastMessage receiptDateForSorting];
 
     if (!_lastMessageDate || [lastMessageDate timeIntervalSinceDate:self.lastMessageDate] > 0) {
         _lastMessageDate = lastMessageDate;

--- a/src/Messages/Interactions/TSIncomingMessage.h
+++ b/src/Messages/Interactions/TSIncomingMessage.h
@@ -121,13 +121,6 @@ extern NSString *const TSIncomingMessageWasReadOnThisDeviceNotification;
 
 @property (nonatomic, readonly) NSString *authorId;
 @property (nonatomic, readonly, getter=wasRead) BOOL read;
-// _DO NOT_ access this property directly.  You almost certainly
-// want to use bestReceivedAtDate instead.
-//
-// This property has been superceded by TSMessage.receivedAtData.
-// This property only exists for backwards compatability with messages
-// received before TSMessage.receivedAtData was added.
-@property (nonatomic, readonly) NSDate *receivedAt;
 
 /*
  * Marks a message as having been read on this device (as opposed to responding to a remote read receipt).

--- a/src/Messages/Interactions/TSIncomingMessage.h
+++ b/src/Messages/Interactions/TSIncomingMessage.h
@@ -121,6 +121,12 @@ extern NSString *const TSIncomingMessageWasReadOnThisDeviceNotification;
 
 @property (nonatomic, readonly) NSString *authorId;
 @property (nonatomic, readonly, getter=wasRead) BOOL read;
+// _DO NOT_ access this property directly.  You almost certainly
+// want to use bestReceivedAtDate instead.
+//
+// This property has been superceded by TSMessage.receivedAtData.
+// This property only exists for backwards compatability with messages
+// received before TSMessage.receivedAtData was added.
 @property (nonatomic, readonly) NSDate *receivedAt;
 
 /*

--- a/src/Messages/Interactions/TSIncomingMessage.m
+++ b/src/Messages/Interactions/TSIncomingMessage.m
@@ -61,7 +61,8 @@ NSString *const TSIncomingMessageWasReadOnThisDeviceNotification = @"TSIncomingM
 
     _authorId = authorId;
     _read = NO;
-    _receivedAt = [NSDate date];
+
+    OWSAssert(self.receivedAtDate);
 
     return self;
 }
@@ -132,6 +133,18 @@ NSString *const TSIncomingMessageWasReadOnThisDeviceNotification = @"TSIncomingM
     _read = YES;
     [self saveWithTransaction:transaction];
     [self touchThreadWithTransaction:transaction];
+}
+
+- (nullable NSDate *)bestReceivedAtDate
+{
+    NSDate *result = [super bestReceivedAtDate];
+    if (!result) {
+        // For backward compatibility with messages received before
+        // TSMessage.receivedAtData was added, honor TSIncomingMessage.receivedAt
+        // if TSMessage.receivedAtData is not set.
+        result = self.receivedAt;
+    }
+    return result;
 }
 
 #pragma mark - Logging

--- a/src/Messages/Interactions/TSIncomingMessage.m
+++ b/src/Messages/Interactions/TSIncomingMessage.m
@@ -135,18 +135,6 @@ NSString *const TSIncomingMessageWasReadOnThisDeviceNotification = @"TSIncomingM
     [self touchThreadWithTransaction:transaction];
 }
 
-- (nullable NSDate *)bestReceivedAtDate
-{
-    NSDate *result = [super bestReceivedAtDate];
-    if (!result) {
-        // For backward compatibility with messages received before
-        // TSMessage.receivedAtData was added, honor TSIncomingMessage.receivedAt
-        // if TSMessage.receivedAtData is not set.
-        result = self.receivedAt;
-    }
-    return result;
-}
-
 #pragma mark - Logging
 
 + (NSString *)tag

--- a/src/Messages/Interactions/TSInteraction.h
+++ b/src/Messages/Interactions/TSInteraction.h
@@ -31,5 +31,6 @@
 + (instancetype)interactionForTimestamp:(uint64_t)timestamp
                         withTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 
+- (nullable NSDate *)receiptDateForSorting;
 
 @end

--- a/src/Messages/Interactions/TSInteraction.m
+++ b/src/Messages/Interactions/TSInteraction.m
@@ -86,6 +86,11 @@
     return [myNumber unsignedLongLongValue];
 }
 
+- (nullable NSDate *)receiptDateForSorting
+{
+    return self.date;
+}
+
 - (NSString *)description {
     return @"Interaction description";
 }

--- a/src/Messages/Interactions/TSMessage.h
+++ b/src/Messages/Interactions/TSMessage.h
@@ -1,5 +1,6 @@
-//  Created by Frederic Jacobs on 12/11/14.
-//  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "TSInteraction.h"
 
@@ -29,6 +30,9 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 @property (nonatomic, readonly) uint64_t expiresAt;
 @property (nonatomic, readonly) BOOL isExpiringMessage;
 @property (nonatomic, readonly) BOOL shouldStartExpireTimer;
+// _DO NOT_ access this property directly.  You almost certainly
+// want to use bestReceivedAtDate instead.
+@property (nonatomic, readonly) NSDate *receivedAtDate;
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp;
 
@@ -59,6 +63,11 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 - (nullable instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;
 
 - (BOOL)hasAttachments;
+
+// This message should return TSMessage.receivedAtDate for most messages.
+// For messages received before TSMessage.receivedAtDate was added, this
+// will try to return TSIncomingMessage.receivedAt.
+- (nullable NSDate *)bestReceivedAtDate;
 
 @end
 

--- a/src/Messages/Interactions/TSMessage.h
+++ b/src/Messages/Interactions/TSMessage.h
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 @property (nonatomic, readonly) BOOL isExpiringMessage;
 @property (nonatomic, readonly) BOOL shouldStartExpireTimer;
 // _DO NOT_ access this property directly.  You almost certainly
-// want to use bestReceivedAtDate instead.
+// want to use receiptDateForSorting instead.
 @property (nonatomic, readonly) NSDate *receivedAtDate;
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp;
@@ -63,11 +63,6 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 - (nullable instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;
 
 - (BOOL)hasAttachments;
-
-// This message should return TSMessage.receivedAtDate for most messages.
-// For messages received before TSMessage.receivedAtDate was added, this
-// will try to return TSIncomingMessage.receivedAt.
-- (nullable NSDate *)bestReceivedAtDate;
 
 @end
 

--- a/src/Messages/Interactions/TSMessage.m
+++ b/src/Messages/Interactions/TSMessage.m
@@ -132,10 +132,13 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
         _attachmentIds = [NSMutableArray new];
     }
 
-    _schemaVersion = OWSMessageSchemaVersion;
+    if (!_receivedAtDate) {
+        // TSIncomingMessage.receivedAt has been superceded by TSMessage.receivedAtDate.
+        NSDate *receivedAt = [coder decodeObjectForKey:@"receivedAt"];
+        _receivedAtDate = receivedAt;
+    }
 
-    // We _DO NOT_ set _receivedAt_ in this constructor.  We don't want to
-    // set the receivedAt time for old messages in the data store.
+    _schemaVersion = OWSMessageSchemaVersion;
 
     return self;
 }
@@ -220,9 +223,22 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
     return self.expiresInSeconds > 0;
 }
 
-- (nullable NSDate *)bestReceivedAtDate
+- (nullable NSDate *)receiptDateForSorting
 {
-    return self.receivedAtDate;
+    // Prefer receivedAtDate if set, otherwise fallback to date.
+    return self.receivedAtDate ?: self.date;
+}
+
+#pragma mark - Logging
+
++ (NSString *)tag
+{
+    return [NSString stringWithFormat:@"[%@]", self.class];
+}
+
+- (NSString *)tag
+{
+    return self.class.tag;
 }
 
 @end

--- a/src/Messages/Interactions/TSMessage.m
+++ b/src/Messages/Interactions/TSMessage.m
@@ -102,6 +102,7 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
     _expiresInSeconds = expiresInSeconds;
     _expireStartedAt = expireStartedAt;
     [self updateExpiresAt];
+    _receivedAtDate = [NSDate date];
 
     return self;
 }
@@ -132,6 +133,10 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
     }
 
     _schemaVersion = OWSMessageSchemaVersion;
+
+    // We _DO NOT_ set _receivedAt_ in this constructor.  We don't want to
+    // set the receivedAt time for old messages in the data store.
+
     return self;
 }
 
@@ -213,6 +218,11 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
 - (BOOL)isExpiringMessage
 {
     return self.expiresInSeconds > 0;
+}
+
+- (nullable NSDate *)bestReceivedAtDate
+{
+    return self.receivedAtDate;
 }
 
 @end

--- a/src/Messages/Interactions/TSOutgoingMessage.h
+++ b/src/Messages/Interactions/TSOutgoingMessage.h
@@ -1,5 +1,6 @@
-//  Created by Frederic Jacobs on 15/11/14.
-//  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "TSMessage.h"
 

--- a/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/src/Messages/Interactions/TSOutgoingMessage.m
@@ -1,5 +1,6 @@
-//  Created by Frederic Jacobs on 15/11/14.
-//  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "TSOutgoingMessage.h"
 #import "NSDate+millisecondTimeStamp.h"
@@ -85,6 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
         self.groupMetaMessage = TSGroupMessageNone;
     }
+
+    OWSAssert(self.receivedAtDate);
 
     return self;
 }

--- a/src/Storage/TSDatabaseView.m
+++ b/src/Storage/TSDatabaseView.m
@@ -9,6 +9,7 @@
 #import "OWSDevice.h"
 #import "OWSReadTracking.h"
 #import "TSIncomingMessage.h"
+#import "TSOutgoingMessage.h"
 #import "TSStorageManager.h"
 #import "TSThread.h"
 
@@ -265,11 +266,10 @@ NSString *TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevicesData
 + (NSDate *)localTimeReceiveDateForInteraction:(TSInteraction *)interaction {
     NSDate *interactionDate = interaction.date;
 
-    if ([interaction isKindOfClass:[TSIncomingMessage class]]) {
-        TSIncomingMessage *message = (TSIncomingMessage *)interaction;
-
-        if (message.receivedAt) {
-            interactionDate = message.receivedAt;
+    if ([interaction isKindOfClass:[TSMessage class]]) {
+        TSMessage *message = (TSMessage *)interaction;
+        if ([message bestReceivedAtDate]) {
+            interactionDate = [message bestReceivedAtDate];
         }
     }
 

--- a/src/Storage/TSDatabaseView.m
+++ b/src/Storage/TSDatabaseView.m
@@ -264,16 +264,7 @@ NSString *TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevicesData
 }
 
 + (NSDate *)localTimeReceiveDateForInteraction:(TSInteraction *)interaction {
-    NSDate *interactionDate = interaction.date;
-
-    if ([interaction isKindOfClass:[TSMessage class]]) {
-        TSMessage *message = (TSMessage *)interaction;
-        if ([message bestReceivedAtDate]) {
-            interactionDate = [message bestReceivedAtDate];
-        }
-    }
-
-    return interactionDate;
+    return [interaction receiptDateForSorting];
 }
 
 #pragma mark - Logging


### PR DESCRIPTION
A new version of https://github.com/WhisperSystems/SignalServiceKit/pull/107

We were only tracking "received at" timestamps for incoming messages.  I've modified the logic so that we now track this on all `TSMessages` using a "received at data" property.

* We could track this on just `TSIncomingMessages` and `TSOutgoingMessages`, but I chose to do it for all.  I think that makes sense... this will also affect the ordering of `TSErrorMessage`, `TSInfoMessage`, but my impression is that that will be beneficial or have no effect.

One oddity is that I don't want to lose the existing `receivedAt` values from `TSIncomingMessages`, so I've left that property and we use a `bestReceivedAtDate` method to try to use new timestamp but that falls back to the old timestamp if possible.

PTAL @michaelkirk 
