### PR TITLE
Add and honor the “CallKit Privacy” setting.

### DIFF
--- a/src/Storage/AxolotlStore/TSStorageManager+Calling.h
+++ b/src/Storage/AxolotlStore/TSStorageManager+Calling.h
@@ -1,0 +1,20 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "TSStorageManager.h"
+
+@interface TSStorageManager (Calling)
+
+// phoneNumber is an e164 formatted phone number.
+//
+// callKitId is expected to have CallKitCallManager.kAnonymousCallHandlePrefix.
+- (void)setPhoneNumber:(NSString *)phoneNumber forCallKitId:(NSString *)callKitId;
+
+// returns an e164 formatted phone number or nil if no
+// record can be found.
+//
+// callKitId is expected to have CallKitCallManager.kAnonymousCallHandlePrefix.
+- (NSString *)phoneNumberForCallKitId:(NSString *)callKitId;
+
+@end

--- a/src/Storage/AxolotlStore/TSStorageManager+Calling.h
+++ b/src/Storage/AxolotlStore/TSStorageManager+Calling.h
@@ -4,6 +4,8 @@
 
 #import "TSStorageManager.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface TSStorageManager (Calling)
 
 // phoneNumber is an e164 formatted phone number.
@@ -18,3 +20,5 @@
 - (NSString *)phoneNumberForCallKitId:(NSString *)callKitId;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/Storage/AxolotlStore/TSStorageManager+Calling.m
+++ b/src/Storage/AxolotlStore/TSStorageManager+Calling.m
@@ -4,7 +4,9 @@
 
 #import "TSStorageManager+Calling.h"
 
-#define TSStorageManagerCallKitIdToPhoneNumberCollection @"TSStorageManagerCallKitIdToPhoneNumberCollection"
+NS_ASSUME_NONNULL_BEGIN
+
+NSString *const TSStorageManagerCallKitIdToPhoneNumberCollection = @"TSStorageManagerCallKitIdToPhoneNumberCollection";
 
 @implementation TSStorageManager (Calling)
 
@@ -24,3 +26,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/Storage/AxolotlStore/TSStorageManager+Calling.m
+++ b/src/Storage/AxolotlStore/TSStorageManager+Calling.m
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "TSStorageManager+Calling.h"
+
+#define TSStorageManagerCallKitIdToPhoneNumberCollection @"TSStorageManagerCallKitIdToPhoneNumberCollection"
+
+@implementation TSStorageManager (Calling)
+
+- (void)setPhoneNumber:(NSString *)phoneNumber forCallKitId:(NSString *)callKitId
+{
+    OWSAssert(phoneNumber.length > 0);
+    OWSAssert(callKitId.length > 0);
+
+    [self setObject:phoneNumber forKey:callKitId inCollection:TSStorageManagerCallKitIdToPhoneNumberCollection];
+}
+
+- (NSString *)phoneNumberForCallKitId:(NSString *)callKitId
+{
+    OWSAssert(callKitId.length > 0);
+
+    return [self objectForKey:callKitId inCollection:TSStorageManagerCallKitIdToPhoneNumberCollection];
+}
+
+@end


### PR DESCRIPTION
Adds a new TSStorageManager category to persist the "call kit id-to-phone number" mapping.

PTAL @michaelkirk 