### PR TITLE
Fix crash-on-launch for older installs

### DIFF
--- a/src/Storage/OWSIncomingMessageFinder.m
+++ b/src/Storage/OWSIncomingMessageFinder.m
@@ -78,8 +78,11 @@ NSString *const OWSIncomingMessageFinderColumnSourceDeviceId = @"OWSIncomingMess
         if ([object isKindOfClass:[TSIncomingMessage class]]) {
             TSIncomingMessage *incomingMessage = (TSIncomingMessage *)object;
 
+            // On new messages authorId should be set on all incoming messages, but there was a time when authorId was
+            // only set on incoming group messages.
+            NSObject *authorIdOrNull = incomingMessage.authorId ? incomingMessage.authorId : [NSNull null];
             [dict setObject:@(incomingMessage.timestamp) forKey:OWSIncomingMessageFinderColumnTimestamp];
-            [dict setObject:incomingMessage.authorId forKey:OWSIncomingMessageFinderColumnSourceId];
+            [dict setObject:authorIdOrNull forKey:OWSIncomingMessageFinderColumnSourceId];
             [dict setObject:@(incomingMessage.sourceDeviceId) forKey:OWSIncomingMessageFinderColumnSourceDeviceId];
         }
     };


### PR DESCRIPTION
populating the de-duping index assumes authorId is always set for
incoming messages, but this was not always the case.

// FREEBIE

PTAL @charlesmchen 