### PR TITLE
Fix receiving attachments from old clients

### DIFF
--- a/src/Messages/Attachments/OWSAttachmentsProcessor.m
+++ b/src/Messages/Attachments/OWSAttachmentsProcessor.m
@@ -63,9 +63,17 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray<NSString *> *supportedAttachmentIds = [NSMutableArray new];
 
     for (OWSSignalServiceProtosAttachmentPointer *attachmentProto in attachmentProtos) {
+
+        OWSAssert(attachmentProto.id != 0);
+        OWSAssert(attachmentProto.key != nil);
+        OWSAssert(attachmentProto.contentType != nil);
+
+        // digest will be empty for old clients.
+        NSData *digest = attachmentProto.hasDigest ? attachmentProto.digest : nil;
+
         TSAttachmentPointer *pointer = [[TSAttachmentPointer alloc] initWithServerId:attachmentProto.id
                                                                                  key:attachmentProto.key
-                                                                              digest:attachmentProto.digest
+                                                                              digest:digest
                                                                          contentType:attachmentProto.contentType
                                                                                relay:relay];
 

--- a/src/Messages/Attachments/TSAttachmentPointer.h
+++ b/src/Messages/Attachments/TSAttachmentPointer.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithServerId:(UInt64)serverId
                              key:(NSData *)key
-                          digest:(NSData *)digest
+                          digest:(nullable NSData *)digest
                      contentType:(NSString *)contentType
                            relay:(NSString *)relay NS_DESIGNATED_INITIALIZER;
 

--- a/src/Messages/Attachments/TSAttachmentPointer.m
+++ b/src/Messages/Attachments/TSAttachmentPointer.m
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithServerId:(UInt64)serverId
                              key:(NSData *)key
-                          digest:(NSData *)digest
+                          digest:(nullable NSData *)digest
                      contentType:(NSString *)contentType
                            relay:(NSString *)relay
 {
@@ -19,7 +19,6 @@ NS_ASSUME_NONNULL_BEGIN
         return self;
     }
 
-    OWSAssert(digest != nil);
     _digest = digest;
     _failed = NO;
     _downloading = NO;


### PR DESCRIPTION
Introduced with the new digesting. Protobuf's null-object pattern provides an empty NSData when no digest is provided rather than nil.

Thought I tested this, but obviously I did not  =/ 
(test doc updated)

PTAL @charlesmchen 
