### PR TITLE
Only call sendMessage on main thread.

### DIFF
--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -292,6 +292,8 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             success:(void (^)())successHandler
             failure:(void (^)(NSError *error))failureHandler
 {
+    AssertIsOnMainThread();
+
     [self saveMessage:message withState:TSOutgoingMessageStateAttemptingOut];
     OWSSendMessageOperation *sendMessageOperation = [[OWSSendMessageOperation alloc] initWithMessage:message
                                                                                        messageSender:self
@@ -392,7 +394,9 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
         [message.attachmentIds addObject:attachmentStream.uniqueId];
         [message save];
 
-        [self sendMessage:message success:successHandler failure:failureHandler];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self sendMessage:message success:successHandler failure:failureHandler];
+        });
     });
 }
 


### PR DESCRIPTION
fixup to #132 

The proximate cause for this change was a failing assert in the recently
introduced call to `setBackgroundTaskIdentifier` which is synchronized
on the main thread.

But generally, to keep things simple, we prefer calling back on main
thread unless performance dictates otherwise.

PTAL @charlesmchen 
