### PR TITLE
enforce singleton usage for MessagesManager and MessageSender

### DIFF
--- a/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
+++ b/Example/TSKitiOSTestApp/TSKitiOSTestApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		450E3C9A1D96DD2600BF4EB6 /* OWSDisappearingMessagesJobTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 450E3C991D96DD2600BF4EB6 /* OWSDisappearingMessagesJobTest.m */; };
 		4516E3E81DD153CC00DC4206 /* TSGroupThreadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4516E3E71DD153CC00DC4206 /* TSGroupThreadTest.m */; };
 		4516E3EA1DD1542300DC4206 /* TSContactThreadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4516E3E91DD1542300DC4206 /* TSContactThreadTest.m */; };
+		452137231E8D6D2F0048FD10 /* OWSFakeMessageSender.m in Sources */ = {isa = PBXBuildFile; fileRef = 452137221E8D6D2F0048FD10 /* OWSFakeMessageSender.m */; };
 		452EE6CF1D4A754C00E934BA /* TSThreadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 452EE6CE1D4A754C00E934BA /* TSThreadTest.m */; };
 		452EE6D51D4AC43300E934BA /* OWSOrphanedDataCleanerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 452EE6D41D4AC43300E934BA /* OWSOrphanedDataCleanerTest.m */; };
 		453E1FCF1DA8313100DDD7B7 /* OWSMessageSenderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 453E1FCE1DA8313100DDD7B7 /* OWSMessageSenderTest.m */; };
@@ -68,6 +69,8 @@
 		450E3C991D96DD2600BF4EB6 /* OWSDisappearingMessagesJobTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OWSDisappearingMessagesJobTest.m; path = ../../../tests/Messages/OWSDisappearingMessagesJobTest.m; sourceTree = "<group>"; };
 		4516E3E71DD153CC00DC4206 /* TSGroupThreadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TSGroupThreadTest.m; path = ../../../tests/Contacts/TSGroupThreadTest.m; sourceTree = "<group>"; };
 		4516E3E91DD1542300DC4206 /* TSContactThreadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TSContactThreadTest.m; path = ../../../tests/Contacts/TSContactThreadTest.m; sourceTree = "<group>"; };
+		452137211E8D6D2F0048FD10 /* OWSFakeMessageSender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OWSFakeMessageSender.h; path = ../../../tests/TestSupport/Fakes/OWSFakeMessageSender.h; sourceTree = "<group>"; };
+		452137221E8D6D2F0048FD10 /* OWSFakeMessageSender.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OWSFakeMessageSender.m; path = ../../../tests/TestSupport/Fakes/OWSFakeMessageSender.m; sourceTree = "<group>"; };
 		452EE6CE1D4A754C00E934BA /* TSThreadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TSThreadTest.m; path = ../../../tests/Contacts/TSThreadTest.m; sourceTree = "<group>"; };
 		452EE6D41D4AC43300E934BA /* OWSOrphanedDataCleanerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OWSOrphanedDataCleanerTest.m; sourceTree = "<group>"; };
 		453E1FCE1DA8313100DDD7B7 /* OWSMessageSenderTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OWSMessageSenderTest.m; path = ../../../tests/Messages/OWSMessageSenderTest.m; sourceTree = "<group>"; };
@@ -164,6 +167,8 @@
 				45AE484B1E072871004D96C2 /* OWSFakeCallMessageHandler.m */,
 				45AE484D1E072906004D96C2 /* OWSFakeNotificationsManager.h */,
 				45AE484E1E072906004D96C2 /* OWSFakeNotificationsManager.m */,
+				452137211E8D6D2F0048FD10 /* OWSFakeMessageSender.h */,
+				452137221E8D6D2F0048FD10 /* OWSFakeMessageSender.m */,
 			);
 			name = Fakes;
 			sourceTree = "<group>";
@@ -566,6 +571,7 @@
 				459850C11D22C6F2006FFEDB /* PhoneNumberTest.m in Sources */,
 				45458B7A1CC342B600A02153 /* TSStorageSignedPreKeyStore.m in Sources */,
 				453E1FDB1DA83EFB00DDD7B7 /* OWSFakeContactsUpdater.m in Sources */,
+				452137231E8D6D2F0048FD10 /* OWSFakeMessageSender.m in Sources */,
 				D2AECE731DE8C3360068CE15 /* ContactSortingTest.m in Sources */,
 				453E1FD81DA83E1000DDD7B7 /* OWSFakeContactsManager.m in Sources */,
 				454021ED1D960ABF00F2126D /* OWSDisappearingMessageFinderTest.m in Sources */,

--- a/src/Messages/TSMessagesManager.h
+++ b/src/Messages/TSMessagesManager.h
@@ -1,5 +1,6 @@
-//  Created by Frederic Jacobs on 11/11/14.
-//  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "TSIncomingMessage.h"
 #import "TSInvalidIdentityKeySendingErrorMessage.h"
@@ -20,14 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TSMessagesManager : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
-
-- (instancetype)initWithNetworkManager:(TSNetworkManager *)networkManager
-                        storageManager:(TSStorageManager *)storageManager
-                    callMessageHandler:(id<OWSCallMessageHandler>)callMessageHandler
-                       contactsManager:(id<ContactsManagerProtocol>)contactsManager
-                       contactsUpdater:(ContactsUpdater *)contactsUpdater
-                         messageSender:(OWSMessageSender *)messageSender NS_DESIGNATED_INITIALIZER;
-
 + (instancetype)sharedManager;
 
 @property (nonatomic, readonly) YapDatabaseConnection *dbConnection;

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -69,10 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
     id<ContactsManagerProtocol> contactsManager = [TextSecureKitEnv sharedEnv].contactsManager;
     id<OWSCallMessageHandler> callMessageHandler = [TextSecureKitEnv sharedEnv].callMessageHandler;
     ContactsUpdater *contactsUpdater = [ContactsUpdater sharedUpdater];
-    OWSMessageSender *messageSender = [[OWSMessageSender alloc] initWithNetworkManager:networkManager
-                                                                        storageManager:storageManager
-                                                                       contactsManager:contactsManager
-                                                                       contactsUpdater:contactsUpdater];
+    OWSMessageSender *messageSender = [TextSecureKitEnv sharedEnv].messageSender;
 
     return [self initWithNetworkManager:networkManager
                          storageManager:storageManager

--- a/src/TextSecureKitEnv.h
+++ b/src/TextSecureKitEnv.h
@@ -1,12 +1,11 @@
 //
-//  TextSecureKitEnv.h
-//  Pods
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
-//  Created by Frederic Jacobs on 05/12/15.
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol ContactsManagerProtocol;
+@class OWSMessageSender;
 @protocol NotificationsProtocol;
 @protocol OWSCallMessageHandler;
 
@@ -14,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithCallMessageHandler:(id<OWSCallMessageHandler>)callMessageHandler
                            contactsManager:(id<ContactsManagerProtocol>)contactsManager
+                             messageSender:(OWSMessageSender *)messageSender
                       notificationsManager:(id<NotificationsProtocol>)notificationsManager NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -21,10 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedEnv;
 + (void)setSharedEnv:(TextSecureKitEnv *)env;
 
-@property (nonatomic, readonly, strong) id<OWSCallMessageHandler> callMessageHandler;
-@property (nonatomic, readonly, strong) id<ContactsManagerProtocol> contactsManager;
-@property (nonatomic, readonly, strong) id<NotificationsProtocol> notificationsManager;
-
+@property (nonatomic, readonly) id<OWSCallMessageHandler> callMessageHandler;
+@property (nonatomic, readonly) id<ContactsManagerProtocol> contactsManager;
+@property (nonatomic, readonly) OWSMessageSender *messageSender;
+@property (nonatomic, readonly) id<NotificationsProtocol> notificationsManager;
 
 @end
 

--- a/src/TextSecureKitEnv.m
+++ b/src/TextSecureKitEnv.m
@@ -10,12 +10,14 @@ static TextSecureKitEnv *TextSecureKitEnvSharedInstance;
 
 @implementation TextSecureKitEnv
 
-@synthesize callMessageHandler = _callMessageHandler;
-@synthesize contactsManager = _contactsManager;
-@synthesize notificationsManager = _notificationsManager;
+@synthesize callMessageHandler = _callMessageHandler,
+    contactsManager = _contactsManager,
+    messageSender = _messageSender,
+    notificationsManager = _notificationsManager;
 
 - (instancetype)initWithCallMessageHandler:(id<OWSCallMessageHandler>)callMessageHandler
                            contactsManager:(id<ContactsManagerProtocol>)contactsManager
+                             messageSender:(OWSMessageSender *)messageSender
                       notificationsManager:(id<NotificationsProtocol>)notificationsManager
 {
     self = [super init];
@@ -25,6 +27,7 @@ static TextSecureKitEnv *TextSecureKitEnvSharedInstance;
 
     _callMessageHandler = callMessageHandler;
     _contactsManager = contactsManager;
+    _messageSender = messageSender;
     _notificationsManager = notificationsManager;
 
     return self;
@@ -55,10 +58,14 @@ static TextSecureKitEnv *TextSecureKitEnvSharedInstance;
 - (id<ContactsManagerProtocol>)contactsManager
 {
     NSAssert(_contactsManager, @"Trying to access the contactsManager before it's set.");
-
     return _contactsManager;
 }
 
+- (OWSMessageSender *)messageSender
+{
+    NSAssert(_messageSender, @"Trying to access the messageSender before it's set.");
+    return _messageSender;
+}
 
 - (id<NotificationsProtocol>)notificationsManager
 {

--- a/tests/Messages/TSMessagesManagerTest.m
+++ b/tests/Messages/TSMessagesManagerTest.m
@@ -1,5 +1,6 @@
-//  Created by Michael Kirk on 9/23/16.
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import <XCTest/XCTest.h>
 
@@ -20,6 +21,15 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface TSMessagesManager (Testing)
+
+// Private init for stubbing dependencies
+
+- (instancetype)initWithNetworkManager:(TSNetworkManager *)networkManager
+                        storageManager:(TSStorageManager *)storageManager
+                    callMessageHandler:(id<OWSCallMessageHandler>)callMessageHandler
+                       contactsManager:(id<ContactsManagerProtocol>)contactsManager
+                       contactsUpdater:(ContactsUpdater *)contactsUpdater
+                         messageSender:(OWSMessageSender *)messageSender;
 
 // private method we are testing
 - (void)handleIncomingEnvelope:(OWSSignalServiceProtosEnvelope *)messageEnvelope

--- a/tests/Messages/TSMessagesManagerTest.m
+++ b/tests/Messages/TSMessagesManagerTest.m
@@ -10,6 +10,7 @@
 #import "OWSFakeCallMessageHandler.h"
 #import "OWSFakeContactsManager.h"
 #import "OWSFakeContactsUpdater.h"
+#import "OWSFakeMessageSender.h"
 #import "OWSFakeNetworkManager.h"
 #import "OWSMessageSender.h"
 #import "OWSSignalServiceProtos.pb.h"
@@ -37,40 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)handleIncomingEnvelope:(OWSSignalServiceProtosEnvelope *)messageEnvelope
                withDataMessage:(OWSSignalServiceProtosDataMessage *)dataMessage;
-
-@end
-
-@interface OWSFakeMessageSender : OWSMessageSender
-
-@property (nonatomic, readonly) XCTestExpectation *expectation;
-
-@end
-
-@implementation OWSFakeMessageSender
-
-- (instancetype)initWithExpectation:(XCTestExpectation *)expectation
-{
-    self = [self init];
-    if (!self) {
-        return self;
-    }
-
-    _expectation = expectation;
-
-    return self;
-}
-
-- (void)sendTemporaryAttachmentData:(NSData *)attachmentData
-                        contentType:(NSString *)contentType
-                          inMessage:(TSOutgoingMessage *)outgoingMessage
-                            success:(void (^)())successHandler
-                            failure:(void (^)(NSError *error))failureHandler
-{
-
-    NSLog(@"Faking sendTemporyAttachmentData.");
-    [self.expectation fulfill];
-    successHandler();
-}
 
 @end
 

--- a/tests/TestSupport/Fakes/OWSFakeMessageSender.h
+++ b/tests/TestSupport/Fakes/OWSFakeMessageSender.h
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "OWSMessageSender.h"
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OWSFakeMessageSender : OWSMessageSender
+
+- (instancetype)initWithExpectation:(XCTestExpectation *)expectation;
+
+@property (nonatomic, readonly) XCTestExpectation *expectation;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/TestSupport/Fakes/OWSFakeMessageSender.m
+++ b/tests/TestSupport/Fakes/OWSFakeMessageSender.m
@@ -1,0 +1,37 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "OWSFakeMessageSender.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSFakeMessageSender
+
+- (instancetype)initWithExpectation:(XCTestExpectation *)expectation
+{
+    self = [self init];
+    if (!self) {
+        return self;
+    }
+
+    _expectation = expectation;
+
+    return self;
+}
+
+- (void)sendTemporaryAttachmentData:(NSData *)attachmentData
+                        contentType:(NSString *)contentType
+                          inMessage:(TSOutgoingMessage *)outgoingMessage
+                            success:(void (^)())successHandler
+                            failure:(void (^)(NSError *error))failureHandler
+{
+
+    NSLog(@"Faking sendTemporyAttachmentData.");
+    [self.expectation fulfill];
+    successHandler();
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/TestSupport/Fakes/OWSUnitTestEnvironment.m
+++ b/tests/TestSupport/Fakes/OWSUnitTestEnvironment.m
@@ -1,9 +1,11 @@
-//  Created by Michael Kirk on 12/18/16.
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "OWSUnitTestEnvironment.h"
 #import "OWSFakeCallMessageHandler.h"
 #import "OWSFakeContactsManager.h"
+#import "OWSFakeMessageSender.h"
 #import "OWSFakeNotificationsManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -14,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     return [super initWithCallMessageHandler:[OWSFakeCallMessageHandler new]
                              contactsManager:[OWSFakeContactsManager new]
+                               messageSender:[OWSFakeMessageSender new]
                         notificationsManager:[OWSFakeNotificationsManager new]];
 }
 


### PR DESCRIPTION
An alternative approach to #154 

Corresponds to iOS PR: https://github.com/WhisperSystems/Signal-iOS/pull/1917#pullrequestreview-30051758

PTAL @charlesmchen 