### PR TITLE
ensure all session access happens on the sessionStoreQueue

### DIFF
--- a/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.m
+++ b/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.m
@@ -1,5 +1,6 @@
-//  Created by Frederic Jacobs on 15/02/15.
-//  Copyright (c) 2015 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "TSInvalidIdentityKeySendingErrorMessage.h"
 #import "OWSFingerprint.h"
@@ -56,7 +57,10 @@ NSString *TSInvalidRecipientKey = @"TSInvalidRecipientKey";
 
 - (void)acceptNewIdentityKey
 {
-    [[TSStorageManager sharedManager] saveRemoteIdentity:self.newIdentityKey recipientId:self.recipientId];
+    // Saving a new identity mutates the session store so it must happen on the sessionStoreQueue
+    dispatch_async([OWSDispatch sessionStoreQueue], ^{
+        [[TSStorageManager sharedManager] saveRemoteIdentity:self.newIdentityKey recipientId:self.recipientId];
+    });
 }
 
 - (NSData *)newIdentityKey

--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -42,11 +42,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(major, minor)                                                          \
-    ([[NSProcessInfo processInfo]                                                                                      \
-        isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){                                                    \
-                                            .majorVersion = major, .minorVersion = minor, .patchVersion = 0 }])
-
 /**
  * OWSSendMessageOperation encapsulates all the work associated with sending a message, e.g. uploading attachments,
  * getting proper keys, and retrying upon failure.

--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -993,7 +993,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             __block NSException *encryptionException;
             // Mutating session state is not thread safe, so we operate on a serial queue, shared with decryption
             // operations.
-            dispatch_sync([OWSDispatch sessionCipher], ^{
+            dispatch_sync([OWSDispatch sessionStoreQueue], ^{
                 @try {
                     messageDict = [self encryptedMessageWithPlaintext:plainText
                                                           toRecipient:recipient.uniqueId

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -251,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
             return;
         }
 
-        dispatch_async([OWSDispatch sessionCipher], ^{
+        dispatch_async([OWSDispatch sessionStoreQueue], ^{
             NSData *plaintextData;
 
             @try {
@@ -300,7 +300,7 @@ NS_ASSUME_NONNULL_BEGIN
             return;
         }
 
-        dispatch_async([OWSDispatch sessionCipher], ^{
+        dispatch_async([OWSDispatch sessionStoreQueue], ^{
             NSData *plaintextData;
             @try {
                 // Check whether we need to refresh our PreKeys every time we receive a PreKeyWhisperMessage.

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -581,7 +581,9 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }];
 
-    [[TSStorageManager sharedManager] deleteAllSessionsForContact:endSessionEnvelope.source];
+    dispatch_async([OWSDispatch sessionStoreQueue], ^{
+        [[TSStorageManager sharedManager] deleteAllSessionsForContact:endSessionEnvelope.source];
+    });
 }
 
 - (void)handleExpirationTimerUpdateMessageWithEnvelope:(OWSSignalServiceProtosEnvelope *)envelope

--- a/src/Storage/AxolotlStore/TSStorageManager+SessionStore.m
+++ b/src/Storage/AxolotlStore/TSStorageManager+SessionStore.m
@@ -39,6 +39,9 @@ void AssertIsOnSessionStoreQueue()
 
 - (NSArray *)subDevicesSessions:(NSString *)contactIdentifier
 {
+    // Deprecated. We aren't currently using this anywhere, but it's "required" by the SessionStore protocol.
+    // If we are going to start using it I'd want to re-verify it works as intended.
+    OWSAssert(NO);
     AssertIsOnSessionStoreQueue();
 
     NSDictionary *dictionary =

--- a/src/Storage/AxolotlStore/TSStorageManager+SessionStore.m
+++ b/src/Storage/AxolotlStore/TSStorageManager+SessionStore.m
@@ -6,12 +6,21 @@
 
 #define TSStorageManagerSessionStoreCollection @"TSStorageManagerSessionStoreCollection"
 
-@implementation TSStorageManager (SessionStore)
+void AssertIsOnSessionStoreQueue()
+{
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(10, 0)) {
+        dispatch_assert_queue([OWSDispatch sessionStoreQueue]);
+    } // else, skip assert as it's a development convenience.
+}
 
+@implementation TSStorageManager (SessionStore)
 
 #pragma mark - SessionStore
 
-- (SessionRecord *)loadSession:(NSString *)contactIdentifier deviceId:(int)deviceId {
+- (SessionRecord *)loadSession:(NSString *)contactIdentifier deviceId:(int)deviceId
+{
+    AssertIsOnSessionStoreQueue();
+
     NSDictionary *dictionary =
         [self dictionaryForKey:contactIdentifier inCollection:TSStorageManagerSessionStoreCollection];
 
@@ -28,7 +37,10 @@
     return record;
 }
 
-- (NSArray *)subDevicesSessions:(NSString *)contactIdentifier {
+- (NSArray *)subDevicesSessions:(NSString *)contactIdentifier
+{
+    AssertIsOnSessionStoreQueue();
+
     NSDictionary *dictionary =
         [self objectForKey:contactIdentifier inCollection:TSStorageManagerSessionStoreCollection];
 
@@ -45,7 +57,10 @@
     return subDevicesSessions;
 }
 
-- (void)storeSession:(NSString *)contactIdentifier deviceId:(int)deviceId session:(SessionRecord *)session {
+- (void)storeSession:(NSString *)contactIdentifier deviceId:(int)deviceId session:(SessionRecord *)session
+{
+    AssertIsOnSessionStoreQueue();
+
     // We need to ensure subsequent usage of this SessionRecord does not consider this session as "fresh". Normally this
     // is achieved by marking things as "not fresh" at the point of deserialization - when we fetch a SessionRecord from
     // YapDB (initWithCoder:). However, because YapDB has an object cache, rather than fetching/deserializing, it's
@@ -65,11 +80,17 @@
     [self setObject:dictionary forKey:contactIdentifier inCollection:TSStorageManagerSessionStoreCollection];
 }
 
-- (BOOL)containsSession:(NSString *)contactIdentifier deviceId:(int)deviceId {
+- (BOOL)containsSession:(NSString *)contactIdentifier deviceId:(int)deviceId
+{
+    AssertIsOnSessionStoreQueue();
+
     return [self loadSession:contactIdentifier deviceId:deviceId].sessionState.hasSenderChain;
 }
 
-- (void)deleteSessionForContact:(NSString *)contactIdentifier deviceId:(int)deviceId {
+- (void)deleteSessionForContact:(NSString *)contactIdentifier deviceId:(int)deviceId
+{
+    AssertIsOnSessionStoreQueue();
+
     NSMutableDictionary *dictionary =
         [[self dictionaryForKey:contactIdentifier inCollection:TSStorageManagerSessionStoreCollection] mutableCopy];
 
@@ -82,7 +103,10 @@
     [self setObject:dictionary forKey:contactIdentifier inCollection:TSStorageManagerSessionStoreCollection];
 }
 
-- (void)deleteAllSessionsForContact:(NSString *)contactIdentifier {
+- (void)deleteAllSessionsForContact:(NSString *)contactIdentifier
+{
+    AssertIsOnSessionStoreQueue();
+
     [self removeObjectForKey:contactIdentifier inCollection:TSStorageManagerSessionStoreCollection];
 }
 
@@ -96,6 +120,8 @@
 
 - (void)printAllSessions
 {
+    AssertIsOnSessionStoreQueue();
+
     NSString *tag = @"[TSStorageManager (SessionStore)]";
     [self.dbConnection readWithBlock:^(YapDatabaseReadTransaction *_Nonnull transaction) {
         DDLogDebug(@"%@ All Sessions:", tag);

--- a/src/Storage/AxolotlStore/TSStorageManager+SessionStore.m
+++ b/src/Storage/AxolotlStore/TSStorageManager+SessionStore.m
@@ -93,7 +93,8 @@ void AssertIsOnSessionStoreQueue()
 - (void)deleteSessionForContact:(NSString *)contactIdentifier deviceId:(int)deviceId
 {
     AssertIsOnSessionStoreQueue();
-
+    DDLogInfo(
+        @"[TSStorageManager (SessionStore)] deleting session for contact: %@ device: %d", contactIdentifier, deviceId);
     NSMutableDictionary *dictionary =
         [[self dictionaryForKey:contactIdentifier inCollection:TSStorageManagerSessionStoreCollection] mutableCopy];
 
@@ -109,6 +110,7 @@ void AssertIsOnSessionStoreQueue()
 - (void)deleteAllSessionsForContact:(NSString *)contactIdentifier
 {
     AssertIsOnSessionStoreQueue();
+    DDLogInfo(@"[TSStorageManager (SessionStore)] deleting all sessions for contact:%@", contactIdentifier);
 
     [self removeObjectForKey:contactIdentifier inCollection:TSStorageManagerSessionStoreCollection];
 }

--- a/src/TSPrefix.h
+++ b/src/TSPrefix.h
@@ -4,6 +4,7 @@
 
 #import "Asserts.h"
 #import "Constraints.h"
+#import "iOSVersions.h"
 #import "OWSAnalytics.h"
 #import "OWSDispatch.h"
 #import <CocoaLumberjack/CocoaLumberjack.h>

--- a/src/Util/OWSDispatch.h
+++ b/src/Util/OWSDispatch.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Signal protocol session state must be coordinated on a serial queue. This is sometimes used synchronously,
  * so never dispatching sync *from* this queue to avoid deadlock.
  */
-+ (dispatch_queue_t)sessionCipher;
++ (dispatch_queue_t)sessionStoreQueue;
 
 /**
  * Serial message sending queue

--- a/src/Util/OWSDispatch.m
+++ b/src/Util/OWSDispatch.m
@@ -18,12 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
     return queue;
 }
 
-+ (dispatch_queue_t)sessionCipher
++ (dispatch_queue_t)sessionStoreQueue
 {
     static dispatch_once_t onceToken;
     static dispatch_queue_t queue;
     dispatch_once(&onceToken, ^{
-        queue = dispatch_queue_create("org.whispersystems.signal.sessionCipher", NULL);
+        queue = dispatch_queue_create("org.whispersystems.signal.sessionStoreQueue", NULL);
     });
     return queue;
 }

--- a/src/Util/iOSVersions.h
+++ b/src/Util/iOSVersions.h
@@ -1,0 +1,9 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#include <Availability.h>
+
+#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(major, minor) \
+    ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){.majorVersion = major, .minorVersion = minor, .patchVersion = 0}])


### PR DESCRIPTION
Though mutating was already serialized via the encrypt/decrypt methods in SPK, there were some places where we were deleting and reading outside of the sessionStoreQueue

Doing so required adding a handful of dispatch_async's

PTAL @charlesmchen 