### PR TITLE
Don’t mark messages as failed until all retries are exhausted.

### DIFF
--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -73,6 +73,8 @@ void AssertIsOnSendingQueue()
 
 @end
 
+#pragma mark -
+
 typedef NS_ENUM(NSInteger, OWSSendMessageOperationState) {
     OWSSendMessageOperationStateNew,
     OWSSendMessageOperationStateExecuting,
@@ -85,7 +87,11 @@ typedef NS_ENUM(NSInteger, OWSSendMessageOperationState) {
                      success:(void (^)())successHandler
                      failure:(RetryableFailureHandler)failureHandler;
 
+- (void)saveMessage:(TSOutgoingMessage *)message withError:(NSError *)error;
+
 @end
+
+#pragma mark -
 
 NSString *const OWSSendMessageOperationKeyIsExecuting = @"isExecuting";
 NSString *const OWSSendMessageOperationKeyIsFinished = @"isFinished";
@@ -102,6 +108,8 @@ NSUInteger const OWSSendMessageOperationMaxRetries = 4;
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundTaskIdentifier;
 
 @end
+
+#pragma mark -
 
 @implementation OWSSendMessageOperation
 
@@ -228,6 +236,9 @@ NSUInteger const OWSSendMessageOperationMaxRetries = 4;
             [self tryWithRemainingRetries:remainingRetries - 1];
         } else {
             DDLogWarn(@"%@ Too many failures. Giving up sending.", self.tag);
+
+            [self.messageSender saveMessage:self.message withError:error];
+
             self.failureHandler(error);
         }
     };
@@ -363,17 +374,20 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
                      failure:(RetryableFailureHandler)failureHandler
 {
     DDLogDebug(@"%@ sending message: %@", self.tag, message.debugDescription);
-    RetryableFailureHandler markAndFailureHandler = ^(NSError *error, BOOL isRetryable) {
-        // TODO do we really want to mark this as failed if we're still retrying?
-        [self saveMessage:message withError:error];
-        failureHandler(error, isRetryable);
-    };
 
     [self ensureAnyAttachmentsUploaded:message
-                               success:^() {
-                                   [self deliverMessage:message success:successHandler failure:markAndFailureHandler];
-                               }
-                               failure:markAndFailureHandler];
+        success:^() {
+            [self deliverMessage:message
+                         success:successHandler
+                         failure:^(NSError *error, BOOL isRetryable) {
+                             DDLogDebug(@"%@ Message send attempt failed: %@", self.tag, message.debugDescription);
+                             failureHandler(error, isRetryable);
+                         }];
+        }
+        failure:^(NSError *error, BOOL isRetryable) {
+            DDLogDebug(@"%@ Attachment upload attempt failed: %@", self.tag, message.debugDescription);
+            failureHandler(error, isRetryable);
+        }];
 }
 
 - (void)ensureAnyAttachmentsUploaded:(TSOutgoingMessage *)message

--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -148,6 +148,8 @@ NSUInteger const OWSSendMessageOperationMaxRetries = 4;
             return;
         }
 
+        [strongSelf.messageSender saveMessage:strongSelf.message withError:error];
+
         DDLogDebug(@"%@ failed with error: %@", strongSelf.tag, error);
         aFailureHandler(error);
         [strongSelf markAsComplete];
@@ -236,8 +238,6 @@ NSUInteger const OWSSendMessageOperationMaxRetries = 4;
             [self tryWithRemainingRetries:remainingRetries - 1];
         } else {
             DDLogWarn(@"%@ Too many failures. Giving up sending.", self.tag);
-
-            [self.messageSender saveMessage:self.message withError:error];
 
             self.failureHandler(error);
         }


### PR DESCRIPTION
This explains why attachment failures were leaving message sending in a bad state and subsequent messages were never sent.  We were marking message send failures as failed after the first failure, not when all retries were exhausted.  With attachments, you tend to notice this because they take so long to send.  

This isn't a regression, but now that we've raised the attachment file size limits, people will see this much more often (since the frequency of transfer failure varies as the square of the message size/message send duration).  

PTAL @michaelkirk 

