### PR TITLE
Fix multiple match for SignalRecipient

### DIFF
--- a/src/Contacts/ContactsUpdater.m
+++ b/src/Contacts/ContactsUpdater.m
@@ -94,10 +94,10 @@ NS_ASSUME_NONNULL_BEGIN
         failure(OWSErrorWithCodeDescription(OWSErrorCodeInvalidMethodParameters, @"Cannot lookup zero identifiers"));
         return;
     }
-    
+
     [self contactIntersectionWithSet:[NSSet setWithArray:identifiers]
                              success:^(NSSet<NSString *> *_Nonnull matchedIds) {
-                                 if (matchedIds.count == 1) {
+                                 if (matchedIds.count > 0) {
                                      NSMutableArray<SignalRecipient *> *recipients = [NSMutableArray new];
                                      for (NSString *identifier in matchedIds) {
                                          [recipients addObject:[SignalRecipient recipientWithTextSecureIdentifier:identifier]];


### PR DESCRIPTION
...when searching for contacts by phone number

In practice this was unlikely to be an issue, since it's unlikely you'd match more than one signal recipient since the array of identifiers are so similar.

fixes https://github.com/WhisperSystems/SignalServiceKit/issues/146

PTAL @charlesmchen 