### PR TITLE
Fix outgoing message status for messages sent from linked devices.

### DIFF
--- a/src/Devices/OWSRecordTranscriptJob.m
+++ b/src/Devices/OWSRecordTranscriptJob.m
@@ -86,8 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                                         attachmentIds:[NSMutableArray new]
                                                                      expiresInSeconds:transcript.expirationDuration
                                                                       expireStartedAt:transcript.expirationStartedAt];
-        // Since updateWithWasDelivered is a new message, updateWithWasDelivered will save it.
-        [textMessage updateWithWasDelivered];
+        // Since textMessage is a new message, updateWithWasSentAndDelivered will save it.
+        [textMessage updateWithWasSentAndDelivered];
     }
 }
 

--- a/src/Messages/Interactions/TSOutgoingMessage.h
+++ b/src/Messages/Interactions/TSOutgoingMessage.h
@@ -159,6 +159,7 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 - (void)updateWithCustomMessage:(NSString *)customMessage;
 - (void)updateWithWasDeliveredWithTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 - (void)updateWithWasDelivered;
+- (void)updateWithWasSentAndDelivered;
 
 #pragma mark - Sent Recipients
 

--- a/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/src/Messages/Interactions/TSOutgoingMessage.m
@@ -291,6 +291,17 @@ NSString *const kTSOutgoingMessageSentRecipientAll = @"kTSOutgoingMessageSentRec
     }];
 }
 
+- (void)updateWithWasSentAndDelivered
+{
+    [self.dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        [self applyChangeToSelfAndLatestOutgoingMessage:transaction
+                                            changeBlock:^(TSOutgoingMessage *message) {
+                                                [message setMessageState:TSOutgoingMessageStateSentToService];
+                                                [message setWasDelivered:YES];
+                                            }];
+    }];
+}
+
 #pragma mark - Sent Recipients
 
 - (NSArray<NSString *> *)sentRecipients

--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -1005,7 +1005,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
 
 - (void)handleMessageSentRemotely:(TSOutgoingMessage *)message sentAt:(uint64_t)sentAt
 {
-    [message updateWithWasDelivered];
+    [message updateWithWasSentAndDelivered];
     [self becomeConsistentWithDisappearingConfigurationForMessage:message];
     [self.disappearingMessagesJob setExpirationForMessage:message expirationStartedAt:sentAt];
 }


### PR DESCRIPTION
PTAL @michaelkirk 

See: https://github.com/WhisperSystems/SignalServiceKit/pull/173#discussion_r111617481

IMO these messages need to show up immediately as _delivered_ (and not just _sent_), or they'll never transition to _delivered_.  The bug was that I was _only_ marking them as delivered and not as sent too.