### PR TITLE
Mkirk/sync session reset

### DIFF
--- a/src/Messages/DeviceSyncing/OWSIncomingSentMessageTranscript.h
+++ b/src/Messages/DeviceSyncing/OWSIncomingSentMessageTranscript.h
@@ -1,4 +1,6 @@
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -24,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) TSThread *thread;
 @property (nonatomic, readonly) BOOL isGroupUpdate;
 @property (nonatomic, readonly) BOOL isExpirationTimerUpdate;
+@property (nonatomic, readonly) BOOL isEndSessionMessage;
 @property (nullable, nonatomic, readonly) NSData *groupId;
 @property (nonatomic, readonly) NSString *body;
 @property (nonatomic, readonly) NSArray<OWSSignalServiceProtosAttachmentPointer *> *attachmentPointerProtos;

--- a/src/Messages/DeviceSyncing/OWSIncomingSentMessageTranscript.m
+++ b/src/Messages/DeviceSyncing/OWSIncomingSentMessageTranscript.m
@@ -1,4 +1,6 @@
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "OWSIncomingSentMessageTranscript.h"
 #import "OWSAttachmentsProcessor.h"
@@ -33,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
     _groupId = _dataMessage.group.id;
     _isGroupUpdate = _dataMessage.hasGroup && (_dataMessage.group.type == OWSSignalServiceProtosGroupContextTypeUpdate);
     _isExpirationTimerUpdate = (_dataMessage.flags & OWSSignalServiceProtosDataMessageFlagsExpirationTimerUpdate) != 0;
+    _isEndSessionMessage = (_dataMessage.flags & OWSSignalServiceProtosDataMessageFlagsEndSession) != 0;
 
     return self;
 }

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -404,21 +404,21 @@ NS_ASSUME_NONNULL_BEGIN
         }];
         if (ignoreMessage) {
             // FIXME: https://github.com/WhisperSystems/Signal-iOS/issues/1340
-            DDLogDebug(@"%@ Received message from group that I left or don't know about, ignoring", self.tag);
+            DDLogInfo(@"%@ Received message from group that I left or don't know about, ignoring", self.tag);
             return;
         }
     }
     if ((dataMessage.flags & OWSSignalServiceProtosDataMessageFlagsEndSession) != 0) {
-        DDLogVerbose(@"%@ Received end session message", self.tag);
+        DDLogInfo(@"%@ Received end session message", self.tag);
         [self handleEndSessionMessageWithEnvelope:incomingEnvelope dataMessage:dataMessage];
     } else if ((dataMessage.flags & OWSSignalServiceProtosDataMessageFlagsExpirationTimerUpdate) != 0) {
-        DDLogVerbose(@"%@ Received expiration timer update message", self.tag);
+        DDLogInfo(@"%@ Received expiration timer update message", self.tag);
         [self handleExpirationTimerUpdateMessageWithEnvelope:incomingEnvelope dataMessage:dataMessage];
     } else if (dataMessage.attachments.count > 0) {
-        DDLogVerbose(@"%@ Received media message attachment", self.tag);
+        DDLogInfo(@"%@ Received media message attachment", self.tag);
         [self handleReceivedMediaWithEnvelope:incomingEnvelope dataMessage:dataMessage];
     } else {
-        DDLogVerbose(@"%@ Received data message.", self.tag);
+        DDLogInfo(@"%@ Received data message.", self.tag);
         [self handleReceivedTextMessageWithEnvelope:incomingEnvelope dataMessage:dataMessage];
         if ([self isDataMessageGroupAvatarUpdate:dataMessage]) {
             DDLogVerbose(@"%@ Data message had group avatar attachment", self.tag);


### PR DESCRIPTION
replaces https://github.com/WhisperSystems/SignalServiceKit/pull/178

Alice.1 has a session with Bob.1 and Bob.2
Bob.1 sends an EndSession to Alice
Thus Alice.1 deletes her sessions with Bob.1 and Bob.2
Bob.2 sends Alice1 "hi" (with the existing session - as a regular WM, not a PKWM)
Alice has no session with Bob.2 so cannot decrypt the message.

Instead of Alice.1 deleting *only* the corrupt session for the device, she continues to delete all sessions with Bob, but we rely on Bob.1 to tell Bob.2 to *also* delete it's sessions with Alice (via a sync-transcript of the END_SESSION message). 

This won't work until https://github.com/WhisperSystems/Signal-Desktop/issues/658 is merged, but we need to release this first, otherwise we're not handling the sync-transcript of the END_SESSION message properly. (Instead we would print a normal text bubble with the word TERMINATE)

PTAL @charlesmchen 