### PR TITLE
debug tool: print signed prekey report

### DIFF
--- a/src/Storage/AxolotlStore/TSStorageManager+SignedPreKeyStore.h
+++ b/src/Storage/AxolotlStore/TSStorageManager+SignedPreKeyStore.h
@@ -30,6 +30,10 @@ extern NSString *const TSStorageManagerSignedPreKeyStoreCollection;
 - (void)setFirstPrekeyUpdateFailureDate:(nonnull NSDate *)value;
 - (void)clearFirstPrekeyUpdateFailureDate;
 
+#pragma mark - Debugging
+
+- (void)logSignedPreKeyReport;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
For use in the debug controller.

Example output:

    SignedPreKeys Report:
      currentId: 111111111:
      firstPrekeyUpdateFailureDate: (null)
      prekeyUpdateFailureCount: 0
      All Keys (count: 2):
        #1 <SignedPreKeyRecord: id: 111111111, generatedAt: 2017-04-24 19:23:55 +0000, wasAcceptedByService:YES, signature: <abcdefgh ..>
        #2 <SignedPreKeyRecord: id: 222222222, generatedAt: 2017-04-20 19:23:55 +0000, wasAcceptedByService:YES, signature: <12345678 ..>

PTAL @charlesmchen 