### PR TITLE
Rework the “disappearing messages” logic.

### DIFF
--- a/src/Devices/OWSReadReceiptsProcessor.m
+++ b/src/Devices/OWSReadReceiptsProcessor.m
@@ -17,7 +17,6 @@ NSString *const OWSReadReceiptsProcessorMarkedMessageAsReadNotification =
 @interface OWSReadReceiptsProcessor ()
 
 @property (nonatomic, readonly) NSArray<OWSReadReceipt *> *readReceipts;
-@property (nonatomic, readonly) OWSDisappearingMessagesJob *disappearingMessagesJob;
 @property (nonatomic, readonly) TSStorageManager *storageManager;
 
 @end
@@ -34,7 +33,6 @@ NSString *const OWSReadReceiptsProcessorMarkedMessageAsReadNotification =
 
     _readReceipts = [readReceipts copy];
     _storageManager = storageManager;
-    _disappearingMessagesJob = [[OWSDisappearingMessagesJob alloc] initWithStorageManager:storageManager];
 
     return self;
 }
@@ -85,7 +83,7 @@ NSString *const OWSReadReceiptsProcessorMarkedMessageAsReadNotification =
             [TSIncomingMessage findMessageWithAuthorId:readReceipt.senderId timestamp:readReceipt.timestamp];
         if (message) {
             [message markAsReadFromReadReceipt];
-            [self.disappearingMessagesJob setExpirationForMessage:message expirationStartedAt:readReceipt.timestamp];
+            [OWSDisappearingMessagesJob setExpirationForMessage:message expirationStartedAt:readReceipt.timestamp];
             // If it was previously saved, no need to keep it around any longer.
             [readReceipt remove];
             [[NSNotificationCenter defaultCenter]

--- a/src/Devices/OWSRecordTranscriptJob.m
+++ b/src/Devices/OWSRecordTranscriptJob.m
@@ -4,7 +4,6 @@
 
 #import "OWSRecordTranscriptJob.h"
 #import "OWSAttachmentsProcessor.h"
-#import "OWSDisappearingMessagesJob.h"
 #import "OWSIncomingSentMessageTranscript.h"
 #import "OWSMessageSender.h"
 #import "TSInfoMessage.h"

--- a/src/Messages/Interactions/TSMessage.m
+++ b/src/Messages/Interactions/TSMessage.m
@@ -4,7 +4,6 @@
 
 #import "TSMessage.h"
 #import "NSDate+millisecondTimeStamp.h"
-#import "OWSDisappearingMessagesJob.h"
 #import "TSAttachment.h"
 #import "TSAttachmentPointer.h"
 #import "TSThread.h"

--- a/src/Messages/OWSDisappearingMessagesJob.h
+++ b/src/Messages/OWSDisappearingMessagesJob.h
@@ -1,5 +1,6 @@
-//  Created by Michael Kirk on 9/23/16.
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,15 +11,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OWSDisappearingMessagesJob : NSObject
 
++ (instancetype)sharedJob;
+
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithStorageManager:(TSStorageManager *)storageManager NS_DESIGNATED_INITIALIZER;
 
-- (void)run;
-- (void)setExpirationsForThread:(TSThread *)thread;
-- (void)setExpirationForMessage:(TSMessage *)message;
-- (void)setExpirationForMessage:(TSMessage *)message expirationStartedAt:(uint64_t)expirationStartedAt;
-- (void)runBy:(uint64_t)millisecondTimestamp;
-
++ (void)setExpirationsForThread:(TSThread *)thread;
++ (void)setExpirationForMessage:(TSMessage *)message;
++ (void)setExpirationForMessage:(TSMessage *)message expirationStartedAt:(uint64_t)expirationStartedAt;
 
 /**
  * Synchronize our disappearing messages settings with that of the given message. Useful so we can
@@ -31,8 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
  * @param contactsManager
  *   Provides the contact name responsible for any configuration changes in an info message.
  */
-- (void)becomeConsistentWithConfigurationForMessage:(TSMessage *)message
++ (void)becomeConsistentWithConfigurationForMessage:(TSMessage *)message
                                     contactsManager:(id<ContactsManagerProtocol>)contactsManager;
+
+// Clean up any messages that expired since last launch immediately
+// and continue cleaning in the background.
+- (void)startIfNecessary;
 
 @end
 

--- a/src/Messages/OWSIncomingMessageReadObserver.m
+++ b/src/Messages/OWSIncomingMessageReadObserver.m
@@ -1,5 +1,6 @@
-//  Created by Michael Kirk on 9/24/16.
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "OWSIncomingMessageReadObserver.h"
 #import "NSDate+millisecondTimeStamp.h"
@@ -13,7 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OWSIncomingMessageReadObserver ()
 
 @property BOOL isObserving;
-@property (nonatomic, readonly) OWSDisappearingMessagesJob *disappearingMessagesJob;
 @property (nonatomic, readonly) OWSSendReadReceiptsJob *sendReadReceiptsJob;
 
 @end
@@ -34,7 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     _isObserving = NO;
-    _disappearingMessagesJob = [[OWSDisappearingMessagesJob alloc] initWithStorageManager:storageManager];
     _sendReadReceiptsJob = [[OWSSendReadReceiptsJob alloc] initWithMessageSender:messageSender];
 
     return self;
@@ -61,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     TSIncomingMessage *message = (TSIncomingMessage *)notification.object;
-    [self.disappearingMessagesJob setExpirationForMessage:message];
+    [OWSDisappearingMessagesJob setExpirationForMessage:message];
     [self.sendReadReceiptsJob runWith:message];
 }
 

--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -341,7 +341,6 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
 @property (nonatomic, readonly) YapDatabaseConnection *dbConnection;
 @property (nonatomic, readonly) id<ContactsManagerProtocol> contactsManager;
 @property (nonatomic, readonly) ContactsUpdater *contactsUpdater;
-@property (nonatomic, readonly) OWSDisappearingMessagesJob *disappearingMessagesJob;
 @property (atomic, readonly) NSMutableDictionary<NSString *, NSOperationQueue *> *sendingQueueMap;
 
 @end
@@ -366,7 +365,6 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
 
     _uploadingService = [[OWSUploadingService alloc] initWithNetworkManager:networkManager];
     _dbConnection = storageManager.newDatabaseConnection;
-    _disappearingMessagesJob = [[OWSDisappearingMessagesJob alloc] initWithStorageManager:storageManager];
 
     OWSSingletonAssert();
 
@@ -1060,20 +1058,20 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
         [self sendSyncTranscriptForMessage:message];
     }
 
-    [self.disappearingMessagesJob setExpirationForMessage:message];
+    [OWSDisappearingMessagesJob setExpirationForMessage:message];
 }
 
 - (void)handleMessageSentRemotely:(TSOutgoingMessage *)message sentAt:(uint64_t)sentAt
 {
     [message updateWithWasSentAndDelivered];
     [self becomeConsistentWithDisappearingConfigurationForMessage:message];
-    [self.disappearingMessagesJob setExpirationForMessage:message expirationStartedAt:sentAt];
+    [OWSDisappearingMessagesJob setExpirationForMessage:message expirationStartedAt:sentAt];
 }
 
 - (void)becomeConsistentWithDisappearingConfigurationForMessage:(TSOutgoingMessage *)outgoingMessage
 {
-    [self.disappearingMessagesJob becomeConsistentWithConfigurationForMessage:outgoingMessage
-                                                              contactsManager:self.contactsManager];
+    [OWSDisappearingMessagesJob becomeConsistentWithConfigurationForMessage:outgoingMessage
+                                                            contactsManager:self.contactsManager];
 }
 
 - (void)handleSendToMyself:(TSOutgoingMessage *)outgoingMessage

--- a/src/Messages/TSMessagesManager.h
+++ b/src/Messages/TSMessagesManager.h
@@ -13,7 +13,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class OWSSignalServiceProtosEnvelope;
 @class OWSSignalServiceProtosDataMessage;
 @class ContactsUpdater;
-@class OWSDisappearingMessagesJob;
 @class OWSMessageSender;
 @protocol ContactsManagerProtocol;
 @protocol OWSCallMessageHandler;

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -48,11 +48,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) id<ContactsManagerProtocol> contactsManager;
 @property (nonatomic, readonly) TSStorageManager *storageManager;
 @property (nonatomic, readonly) OWSMessageSender *messageSender;
-@property (nonatomic, readonly) OWSDisappearingMessagesJob *disappearingMessagesJob;
 @property (nonatomic, readonly) OWSIncomingMessageFinder *incomingMessageFinder;
 @property (nonatomic, readonly) OWSBlockingManager *blockingManager;
 
 @end
+
+#pragma mark -
 
 @implementation TSMessagesManager
 
@@ -103,7 +104,6 @@ NS_ASSUME_NONNULL_BEGIN
     _messageSender = messageSender;
 
     _dbConnection = storageManager.newDatabaseConnection;
-    _disappearingMessagesJob = [[OWSDisappearingMessagesJob alloc] initWithStorageManager:storageManager];
     _incomingMessageFinder = [[OWSIncomingMessageFinder alloc] initWithDatabase:storageManager.database];
     _blockingManager = [OWSBlockingManager sharedManager];
 
@@ -940,8 +940,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                        storageManager:self.storageManager];
         [readReceiptsProcessor process];
 
-        [self.disappearingMessagesJob becomeConsistentWithConfigurationForMessage:incomingMessage
-                                                                  contactsManager:self.contactsManager];
+        [OWSDisappearingMessagesJob becomeConsistentWithConfigurationForMessage:incomingMessage
+                                                                contactsManager:self.contactsManager];
 
         // Update thread preview in inbox
         [thread touch];

--- a/src/Util/NSTimer+OWS.h
+++ b/src/Util/NSTimer+OWS.h
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSTimer (OWS)
+
+// This method avoids the classic NSTimer retain cycle bug
+// by using a weak reference to the target.
++ (NSTimer *)weakScheduledTimerWithTimeInterval:(NSTimeInterval)timeInterval
+                                         target:(id)target
+                                       selector:(SEL)selector
+                                       userInfo:(nullable id)userInfo
+                                        repeats:(BOOL)repeats;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Util/NSTimer+OWS.m
+++ b/src/Util/NSTimer+OWS.m
@@ -1,0 +1,69 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "NSTimer+OWS.h"
+#import <objc/runtime.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSTimerProxy : NSObject
+
+@property (nonatomic, weak) id target;
+@property (nonatomic) SEL selector;
+
+@end
+
+#pragma mark -
+
+@implementation NSTimerProxy
+
+- (void)timerFired:(NSDictionary *)userInfo
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    [self.target performSelector:self.selector withObject:userInfo];
+#pragma clang diagnostic pop
+}
+
+@end
+
+#pragma mark -
+
+static void *kNSTimer_OWS_Proxy = &kNSTimer_OWS_Proxy;
+
+@implementation NSTimer (OWS)
+
+- (NSTimerProxy *)ows_proxy
+{
+    return objc_getAssociatedObject(self, kNSTimer_OWS_Proxy);
+}
+
+- (void)ows_setProxy:(NSTimerProxy *)proxy
+{
+    OWSAssert(proxy);
+
+    objc_setAssociatedObject(self, kNSTimer_OWS_Proxy, proxy, OBJC_ASSOCIATION_RETAIN);
+}
+
++ (NSTimer *)weakScheduledTimerWithTimeInterval:(NSTimeInterval)timeInterval
+                                         target:(id)target
+                                       selector:(SEL)selector
+                                       userInfo:(nullable id)userInfo
+                                        repeats:(BOOL)repeats
+{
+    NSTimerProxy *proxy = [NSTimerProxy new];
+    proxy.target = target;
+    proxy.selector = selector;
+    NSTimer *timer = [NSTimer scheduledTimerWithTimeInterval:timeInterval
+                                                      target:proxy
+                                                    selector:@selector(timerFired:)
+                                                    userInfo:userInfo
+                                                     repeats:repeats];
+    [timer ows_setProxy:proxy];
+    return timer;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
* Convert `OWSDisappearingMessagesJob` to a singleton since its work is expensive.
* Ensure `OWSDisappearingMessagesJob` does all of its work on a private queue, off the main thread.
* Rework scheduling of `OWSDisappearingMessagesJob` runs to use a NSTimer, so that we can cancel redundant scheduled runs.
* Move NSTimer+OWS category to SSK.
* Fix bug wherein some disappearing messages never got deleted.

PTAL @michaelkirk 