### PR TITLE
remove checks for other country codes since it's expensive

### DIFF
--- a/src/Contacts/PhoneNumber.m
+++ b/src/Contacts/PhoneNumber.m
@@ -169,18 +169,6 @@ static NSString *const RPDefaultsKeyPhoneNumberCanonical = @"RPDefaultsKeyPhoneN
                                        callingCodeForLocalNumber,
                                        sanitizedString],
                                       [self defaultRegionCode]);
-
-            // It's gratuitous to try all country codes associated with a given
-            // calling code, but it can't hurt and this isn't a performance
-            // hotspot.
-            NSArray *possibleLocalCountryCodes = [PhoneNumberUtil.sharedUtil
-                countryCodesFromCallingCode:[NSString stringWithFormat:@"+%@", callingCodeForLocalNumber]];
-            for (NSString *countryCode in possibleLocalCountryCodes) {
-                tryParsingWithCountryCode([NSString stringWithFormat:@"+%@%@",
-                                           callingCodeForLocalNumber,
-                                           sanitizedString],
-                                          countryCode);
-            }
         }
     }
     


### PR DESCRIPTION
Unfortunately calls to `NBPhoneNumberUtil parse:defaultRegion:error` are
not cheap, calling it with a bunch of permutations on every contact is
too expensive to justify it's incremental value unless we can get
upstream optimized.

e.g. for US numbers this was 26 extra calls per phone number

PTAL @charlesmchen 

**Before**

<img width="1139" alt="screen shot 2017-05-15 at 3 19 45 pm" src="https://cloud.githubusercontent.com/assets/217057/26077348/bcf0e6e2-3989-11e7-93e4-3b15bc290077.png">


**After**

<img width="1003" alt="screen shot 2017-05-15 at 4 16 20 pm" src="https://cloud.githubusercontent.com/assets/217057/26077387/de02d642-3989-11e7-93f3-1a2009ef4718.png">

