### PR TITLE
confirm before sending to untrusted identity

### DIFF
--- a/src/Storage/AxolotlStore/TSStorageManager+IdentityKeyStore.h
+++ b/src/Storage/AxolotlStore/TSStorageManager+IdentityKeyStore.h
@@ -7,6 +7,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class OWSRecipientIdentity;
+
 extern NSString *const TSStorageManagerTrustedKeysCollection;
 
 @interface TSStorageManager (IdentityKeyStore) <IdentityKeyStore>
@@ -28,6 +30,15 @@ extern NSString *const TSStorageManagerTrustedKeysCollection;
                recipientId:(NSString *)recipientId
     approvedForBlockingUse:(BOOL)approvedForBlockingUse
  approvedForNonBlockingUse:(BOOL)approvedForNonBlockingUse;
+
+/**
+ * Check if a recipient identity corresponds to an untrusted identity
+ *
+ * @param   recipientId unique stable identifier for the recipient, e.g. e164 phone number
+ * @returns nil if the identity doesn't exist or if it's trusted
+ *          else returns the untrusted identity
+ */
+- (nullable OWSRecipientIdentity *)unconfirmedIdentityThatShouldBlockSendingForRecipientId:(NSString *)recipientId;
 
 - (void)generateNewIdentityKey;
 - (nullable NSData *)identityKeyForRecipientId:(NSString *)recipientId;

--- a/src/Storage/AxolotlStore/TSStorageManager+IdentityKeyStore.m
+++ b/src/Storage/AxolotlStore/TSStorageManager+IdentityKeyStore.m
@@ -175,6 +175,29 @@ const NSTimeInterval kIdentityKeyStoreNonBlockingSecondsThreshold = 5.0;
     }
 }
 
+- (nullable OWSRecipientIdentity *)unconfirmedIdentityThatShouldBlockSendingForRecipientId:(NSString *)recipientId;
+{
+    OWSAssert(recipientId != nil);
+
+    @synchronized([[self class] sharedIdentityKeyLock])
+    {
+        OWSRecipientIdentity *currentIdentity = [OWSRecipientIdentity fetchObjectWithUniqueID:recipientId];
+        if (currentIdentity == nil) {
+            // No preexisting key, Trust On First Use
+            return nil;
+        }
+
+        if ([self isTrustedIdentityKey:currentIdentity.identityKey
+                           recipientId:currentIdentity.recipientId
+                             direction:TSMessageDirectionOutgoing]) {
+            return nil;
+        }
+
+        // identity not yet trusted for sending
+        return currentIdentity;
+    }
+}
+
 - (BOOL)isTrustedKey:(NSData *)identityKey forSendingToIdentity:(nullable OWSRecipientIdentity *)recipientIdentity
 {
     OWSAssert(identityKey != nil);


### PR DESCRIPTION
based on #231 

Feel free to wait until #231 is merged, but the changes can be seen pretty clearly in:
https://github.com/WhisperSystems/SignalServiceKit/commit/8d93eb036c81d842cf18acbc844070f95b03c369

see also: https://github.com/WhisperSystems/Signal-iOS/pull/2155

PTAL @charlesmchen 