### PR TITLE
Charlesmchen/refine unseen indicator

### DIFF
--- a/src/Contacts/TSThread.m
+++ b/src/Contacts/TSThread.m
@@ -199,6 +199,8 @@ NS_ASSUME_NONNULL_BEGIN
 
                       if (![object conformsToProtocol:@protocol(OWSReadTracking)]) {
                           DDLogError(@"%@ Unexpected object in unseen messages: %@", self.tag, object);
+                          OWSFail(@"Unexpected object in unseen messages.");
+                          return;
                       }
                       [messages addObject:(id<OWSReadTracking>)object];
                   }];

--- a/src/Messages/Interactions/TSErrorMessage.h
+++ b/src/Messages/Interactions/TSErrorMessage.h
@@ -2,12 +2,13 @@
 //  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
+#import "OWSReadTracking.h"
 #import "OWSSignalServiceProtos.pb.h"
 #import "TSMessage.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface TSErrorMessage : TSMessage
+@interface TSErrorMessage : TSMessage <OWSReadTracking>
 
 typedef NS_ENUM(int32_t, TSErrorMessageType) {
     TSErrorMessageNoSession,
@@ -55,6 +56,8 @@ typedef NS_ENUM(int32_t, TSErrorMessageType) {
 
 @property (nonatomic, readonly) TSErrorMessageType errorType;
 @property (nullable, nonatomic, readonly) NSString *recipientId;
+
+- (void)markAsReadLocallyWithTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 @end
 

--- a/src/Messages/Interactions/TSIncomingMessage.h
+++ b/src/Messages/Interactions/TSIncomingMessage.h
@@ -107,7 +107,6 @@ extern NSString *const TSIncomingMessageWasReadOnThisDeviceNotification;
 
 // This will be 0 for messages created before we were tracking sourceDeviceId
 @property (nonatomic, readonly) UInt32 sourceDeviceId;
-@property (nonatomic, readonly, getter=wasRead) BOOL read;
 
 /*
  * Marks a message as having been read on this device (as opposed to responding to a remote read receipt).

--- a/src/Messages/Interactions/TSIncomingMessage.m
+++ b/src/Messages/Interactions/TSIncomingMessage.m
@@ -12,11 +12,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSString *const TSIncomingMessageWasReadOnThisDeviceNotification = @"TSIncomingMessageWasReadOnThisDeviceNotification";
 
+@interface TSIncomingMessage ()
+
+@property (nonatomic, getter=wasRead) BOOL read;
+
+@end
+
+#pragma mark -
+
 @implementation TSIncomingMessage
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    return [super initWithCoder:coder];
+    self = [super initWithCoder:coder];
+    if (!self) {
+        return self;
+    }
+
+    return self;
 }
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
@@ -57,8 +70,6 @@ NSString *const TSIncomingMessageWasReadOnThisDeviceNotification = @"TSIncomingM
     _sourceDeviceId = sourceDeviceId;
     _read = NO;
 
-    OWSAssert(self.receivedAtDate);
-
     return self;
 }
 
@@ -95,6 +106,13 @@ NSString *const TSIncomingMessageWasReadOnThisDeviceNotification = @"TSIncomingM
     }];
 
     return foundMessage;
+}
+
+#pragma mark - OWSReadTracking
+
+- (BOOL)shouldAffectUnreadCounts
+{
+    return YES;
 }
 
 - (void)markAsReadFromReadReceipt

--- a/src/Messages/Interactions/TSInfoMessage.h
+++ b/src/Messages/Interactions/TSInfoMessage.h
@@ -2,11 +2,12 @@
 //  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
+#import "OWSReadTracking.h"
 #import "TSMessage.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface TSInfoMessage : TSMessage
+@interface TSInfoMessage : TSMessage <OWSReadTracking>
 
 typedef NS_ENUM(NSInteger, TSInfoMessageType) {
     TSInfoMessageTypeSessionDidEnd,
@@ -40,6 +41,8 @@ typedef NS_ENUM(NSInteger, TSInfoMessageType) {
                     attachmentIds:(NSArray<NSString *> *)attachmentIds
                  expiresInSeconds:(uint32_t)expiresInSeconds
                   expireStartedAt:(uint64_t)expireStartedAt NS_UNAVAILABLE;
+
+- (void)markAsReadLocallyWithTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 @end
 

--- a/src/Messages/Interactions/TSInfoMessage.m
+++ b/src/Messages/Interactions/TSInfoMessage.m
@@ -2,16 +2,40 @@
 //  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
-#import "NSDate+millisecondTimeStamp.h"
 #import "TSInfoMessage.h"
+#import "NSDate+millisecondTimeStamp.h"
+#import <YapDatabase/YapDatabaseConnection.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+NSUInteger TSInfoMessageSchemaVersion = 1;
+
+@interface TSInfoMessage ()
+
+@property (nonatomic, getter=wasRead) BOOL read;
+
+@property (nonatomic, readonly) NSUInteger infoMessageSchemaVersion;
+
+@end
+
+#pragma mark -
 
 @implementation TSInfoMessage
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    return [super initWithCoder:coder];
+    self = [super initWithCoder:coder];
+    if (!self) {
+        return self;
+    }
+
+    if (self.infoMessageSchemaVersion < 1) {
+        _read = YES;
+    }
+
+    _infoMessageSchemaVersion = TSInfoMessageSchemaVersion;
+
+    return self;
 }
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
@@ -30,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     _messageType = infoMessage;
+    _infoMessageSchemaVersion = TSInfoMessageSchemaVersion;
 
     return self;
 }
@@ -72,6 +97,40 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     return @"Unknown Info Message Type";
+}
+
+#pragma mark - OWSReadTracking
+
+- (BOOL)shouldAffectUnreadCounts
+{
+    return NO;
+}
+
+- (void)markAsReadLocally
+{
+    [self.dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        [self markAsReadLocallyWithTransaction:transaction];
+    }];
+}
+
+- (void)markAsReadLocallyWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
+{
+    OWSAssert(transaction);
+    DDLogInfo(@"%@ marking as read uniqueId: %@ which has timestamp: %llu", self.tag, self.uniqueId, self.timestamp);
+    _read = YES;
+    [self saveWithTransaction:transaction];
+}
+
+#pragma mark - Logging
+
++ (NSString *)tag
+{
+    return [NSString stringWithFormat:@"[%@]", self.class];
+}
+
+- (NSString *)tag
+{
+    return self.class.tag;
 }
 
 @end

--- a/src/Messages/Interactions/TSInteraction.h
+++ b/src/Messages/Interactions/TSInteraction.h
@@ -16,7 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) TSThread *thread;
 @property (nonatomic, readonly) uint64_t timestamp;
 
-- (NSDate *)date;
 - (NSString *)description;
 
 /**
@@ -33,7 +32,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)interactionForTimestamp:(uint64_t)timestamp
                         withTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 
-- (nullable NSDate *)receiptDateForSorting;
+// NSDate has second precision, uint64_t timestamps have millisecond precision
+// so prefer timestampForSorting over dateForSorting.
+- (NSDate *)dateForSorting;
+- (uint64_t)timestampForSorting;
 
 // "Dynamic" interactions are not messages or static events (like
 // info messages, error messages, etc.).  They are interactions

--- a/src/Messages/Interactions/TSInteraction.h
+++ b/src/Messages/Interactions/TSInteraction.h
@@ -32,10 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)interactionForTimestamp:(uint64_t)timestamp
                         withTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 
-// NSDate has second precision, uint64_t timestamps have millisecond precision
-// so prefer timestampForSorting over dateForSorting.
 - (NSDate *)dateForSorting;
 - (uint64_t)timestampForSorting;
+- (NSComparisonResult)compareForSorting:(TSInteraction *)other;
 
 // "Dynamic" interactions are not messages or static events (like
 // info messages, error messages, etc.).  They are interactions

--- a/src/Messages/Interactions/TSInteraction.h
+++ b/src/Messages/Interactions/TSInteraction.h
@@ -35,6 +35,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSDate *)receiptDateForSorting;
 
+// "Dynamic" interactions are not messages or static events (like
+// info messages, error messages, etc.).  They are interactions
+// created, updated and deleted by the views.
+//
+// These include block offers, "add to contact" offers,
+// unseen message indicators, etc.
+- (BOOL)isDynamicInteraction;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/Messages/Interactions/TSInteraction.m
+++ b/src/Messages/Interactions/TSInteraction.m
@@ -109,6 +109,11 @@ NS_ASSUME_NONNULL_BEGIN
     [fetchedThread updateWithLastMessage:self transaction:transaction];
 }
 
+- (BOOL)isDynamicInteraction
+{
+    return NO;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/Messages/Interactions/TSInteraction.m
+++ b/src/Messages/Interactions/TSInteraction.m
@@ -3,6 +3,7 @@
 //
 
 #import "TSInteraction.h"
+#import "NSDate+millisecondTimeStamp.h"
 #import "TSDatabaseSecondaryIndexes.h"
 #import "TSStorageManager+messageIDs.h"
 #import "TSThread.h"
@@ -52,7 +53,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-
 #pragma mark Thread
 
 - (TSThread *)thread
@@ -72,11 +72,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self.timestamp;
 }
 
-- (NSDate *)date {
-    uint64_t seconds = self.timestamp / 1000;
-    return [NSDate dateWithTimeIntervalSince1970:seconds];
-}
-
 + (NSString *)stringFromTimeStamp:(uint64_t)timestamp {
     return [[NSNumber numberWithUnsignedLongLong:timestamp] stringValue];
 }
@@ -88,9 +83,14 @@ NS_ASSUME_NONNULL_BEGIN
     return [myNumber unsignedLongLongValue];
 }
 
-- (nullable NSDate *)receiptDateForSorting
+- (NSDate *)dateForSorting
 {
-    return self.date;
+    return [NSDate ows_dateWithMillisecondsSince1970:self.timestampForSorting];
+}
+
+- (uint64_t)timestampForSorting
+{
+    return self.timestamp;
 }
 
 - (NSString *)description {

--- a/src/Messages/Interactions/TSInteraction.m
+++ b/src/Messages/Interactions/TSInteraction.m
@@ -93,6 +93,22 @@ NS_ASSUME_NONNULL_BEGIN
     return self.timestamp;
 }
 
+- (NSComparisonResult)compareForSorting:(TSInteraction *)other
+{
+    OWSAssert(other);
+
+    uint64_t timestamp1 = self.timestampForSorting;
+    uint64_t timestamp2 = other.timestampForSorting;
+
+    if (timestamp1 > timestamp2) {
+        return NSOrderedDescending;
+    } else if (timestamp1 < timestamp2) {
+        return NSOrderedAscending;
+    } else {
+        return NSOrderedSame;
+    }
+}
+
 - (NSString *)description {
     return @"Interaction description";
 }

--- a/src/Messages/Interactions/TSMessage.h
+++ b/src/Messages/Interactions/TSMessage.h
@@ -21,9 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) uint64_t expiresAt;
 @property (nonatomic, readonly) BOOL isExpiringMessage;
 @property (nonatomic, readonly) BOOL shouldStartExpireTimer;
-// _DO NOT_ access this property directly.  You almost certainly
-// want to use receiptDateForSorting instead.
-@property (nonatomic, readonly) NSDate *receivedAtDate;
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp;
 

--- a/src/Messages/Interactions/TSMessage.m
+++ b/src/Messages/Interactions/TSMessage.m
@@ -111,12 +111,7 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
     _expiresInSeconds = expiresInSeconds;
     _expireStartedAt = expireStartedAt;
     [self updateExpiresAt];
-
-    if ([self shouldUseReceiptDateForSorting]) {
-        _receivedAtTimestamp = self.timestamp;
-    } else {
-        _receivedAtTimestamp = [NSDate ows_millisecondTimeStamp];
-    }
+    _receivedAtTimestamp = [NSDate ows_millisecondTimeStamp];
 
     return self;
 }
@@ -155,10 +150,6 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
         if (receivedAtDate) {
             _receivedAtTimestamp = [NSDate ows_millisecondsSince1970ForDate:receivedAtDate];
         }
-    }
-
-    if ([self shouldUseReceiptDateForSorting]) {
-        _receivedAtTimestamp = self.timestamp;
     }
 
     _schemaVersion = OWSMessageSchemaVersion;

--- a/src/Messages/Interactions/TSMessage.m
+++ b/src/Messages/Interactions/TSMessage.m
@@ -35,6 +35,13 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
  */
 @property (nonatomic, readonly) NSUInteger schemaVersion;
 
+// The timestamp property is populated by the envelope,
+// which is created by the sender.
+//
+// We typically want to order messages locally by when
+// they were received & decrypted, not by when they were sent.
+@property (nonatomic, readonly) uint64_t receivedAtTimestamp;
+
 @end
 
 #pragma mark -
@@ -104,7 +111,12 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
     _expiresInSeconds = expiresInSeconds;
     _expireStartedAt = expireStartedAt;
     [self updateExpiresAt];
-    _receivedAtDate = [NSDate date];
+
+    if ([self shouldUseReceiptDateForSorting]) {
+        _receivedAtTimestamp = self.timestamp;
+    } else {
+        _receivedAtTimestamp = [NSDate ows_millisecondTimeStamp];
+    }
 
     return self;
 }
@@ -133,10 +145,20 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
         _attachmentIds = [NSMutableArray new];
     }
 
-    if (!_receivedAtDate) {
-        // TSIncomingMessage.receivedAt has been superceded by TSMessage.receivedAtDate.
-        NSDate *receivedAt = [coder decodeObjectForKey:@"receivedAt"];
-        _receivedAtDate = receivedAt;
+    if (_receivedAtTimestamp == 0) {
+        // Upgrade from the older "receivedAtDate" and "receivedAt" properties if
+        // necessary.
+        NSDate *receivedAtDate = [coder decodeObjectForKey:@"receivedAtDate"];
+        if (!receivedAtDate) {
+            receivedAtDate = [coder decodeObjectForKey:@"receivedAt"];
+        }
+        if (receivedAtDate) {
+            _receivedAtTimestamp = [NSDate ows_millisecondsSince1970ForDate:receivedAtDate];
+        }
+    }
+
+    if ([self shouldUseReceiptDateForSorting]) {
+        _receivedAtTimestamp = self.timestamp;
     }
 
     _schemaVersion = OWSMessageSchemaVersion;
@@ -224,10 +246,19 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
     return self.expiresInSeconds > 0;
 }
 
-- (nullable NSDate *)receiptDateForSorting
+- (uint64_t)timestampForSorting
 {
-    // Prefer receivedAtDate if set, otherwise fallback to date.
-    return self.receivedAtDate ?: self.date;
+    if ([self shouldUseReceiptDateForSorting] && self.receivedAtTimestamp > 0) {
+        return self.receivedAtTimestamp;
+    } else {
+        OWSAssert(self.timestamp > 0);
+        return self.timestamp;
+    }
+}
+
+- (BOOL)shouldUseReceiptDateForSorting
+{
+    return YES;
 }
 
 #pragma mark - Logging

--- a/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/src/Messages/Interactions/TSOutgoingMessage.m
@@ -186,8 +186,6 @@ NSString *const kTSOutgoingMessageSentRecipientAll = @"kTSOutgoingMessageSentRec
 
     _attachmentFilenameMap = [NSMutableDictionary new];
 
-    OWSAssert(self.receivedAtDate);
-
     return self;
 }
 

--- a/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyErrorMessage.m
+++ b/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyErrorMessage.m
@@ -1,9 +1,5 @@
 //
-//  TSInvalidIdentityKeyErrorMessage.m
-//  Signal
-//
-//  Created by Frederic Jacobs on 15/02/15.
-//  Copyright (c) 2015 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
 #import "TSInvalidIdentityKeyErrorMessage.h"
@@ -27,6 +23,11 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSAssert(NO, @"Method needs to be implemented in subclasses of TSInvalidIdentityKeyErrorMessage.");
     return nil;
+}
+
+- (BOOL)isDynamicInteraction
+{
+    return YES;
 }
 
 @end

--- a/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyErrorMessage.m
+++ b/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyErrorMessage.m
@@ -25,11 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
     return nil;
 }
 
-- (BOOL)isDynamicInteraction
-{
-    return YES;
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSAddToContactsOfferMessage.m
+++ b/src/Messages/OWSAddToContactsOfferMessage.m
@@ -42,6 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self.date;
 }
 
+- (BOOL)isDynamicInteraction
+{
+    return YES;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSAddToContactsOfferMessage.m
+++ b/src/Messages/OWSAddToContactsOfferMessage.m
@@ -32,14 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (nullable NSDate *)receiptDateForSorting
+- (BOOL)shouldUseReceiptDateForSorting
 {
-    // Always use date, since we're creating these interactions after the fact
-    // and back-dating them.
-    //
-    // By default [TSMessage receiptDateForSorting] will prefer to use receivedAtDate
-    // which is not back-dated.
-    return self.date;
+    // Use the timestamp, not the "received at" timestamp to sort,
+    // since we're creating these interactions after the fact and back-dating them.
+    return NO;
 }
 
 - (BOOL)isDynamicInteraction

--- a/src/Messages/OWSReadTracking.h
+++ b/src/Messages/OWSReadTracking.h
@@ -15,13 +15,15 @@
  */
 @property (nonatomic, readonly, getter=wasRead) BOOL read;
 
+@property (nonatomic, readonly) NSString *uniqueThreadId;
+
+- (BOOL)shouldAffectUnreadCounts;
+
 /**
  * Call when the user viewed the message/call on this device. "locally" as opposed to being notified via a read receipt
  * sync message of a remote read.
  */
 - (void)markAsReadLocally;
 - (void)markAsReadLocallyWithTransaction:(YapDatabaseReadWriteTransaction *)transaction;
-
-@property (nonatomic, readonly) NSString *uniqueThreadId;
 
 @end

--- a/src/Messages/OWSUnknownContactBlockOfferMessage.m
+++ b/src/Messages/OWSUnknownContactBlockOfferMessage.m
@@ -44,6 +44,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self.date;
 }
 
+- (BOOL)isDynamicInteraction
+{
+    return YES;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/Messages/OWSUnknownContactBlockOfferMessage.m
+++ b/src/Messages/OWSUnknownContactBlockOfferMessage.m
@@ -34,14 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (nullable NSDate *)receiptDateForSorting
+- (BOOL)shouldUseReceiptDateForSorting
 {
-    // Always use date, since we're creating these interactions after the fact
-    // and back-dating them.
-    //
-    // By default [TSMessage receiptDateForSorting] will prefer to use receivedAtDate
-    // which is not back-dated.
-    return self.date;
+    // Use the timestamp, not the "received at" timestamp to sort,
+    // since we're creating these interactions after the fact and back-dating them.
+    return NO;
 }
 
 - (BOOL)isDynamicInteraction

--- a/src/Messages/TSCall.m
+++ b/src/Messages/TSCall.m
@@ -13,13 +13,15 @@ NSUInteger TSCallCurrentSchemaVersion = 1;
 
 @interface TSCall ()
 
+@property (nonatomic, getter=wasRead) BOOL read;
+
 @property (nonatomic, readonly) NSUInteger callSchemaVersion;
 
 @end
 
-@implementation TSCall
+#pragma mark -
 
-@synthesize read = _read;
+@implementation TSCall
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
                    withCallNumber:(NSString *)contactNumber
@@ -76,6 +78,11 @@ NSUInteger TSCallCurrentSchemaVersion = 1;
 }
 
 #pragma mark - OWSReadTracking
+
+- (BOOL)shouldAffectUnreadCounts
+{
+    return YES;
+}
 
 - (void)markAsReadLocallyWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
 {

--- a/src/Security/OWSRecipientIdentity.m
+++ b/src/Security/OWSRecipientIdentity.m
@@ -4,6 +4,7 @@
 
 #import "OWSRecipientIdentity.h"
 #import "TSStorageManager.h"
+#import <YapDatabase/YapDatabaseConnection.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -91,9 +92,11 @@ NS_ASSUME_NONNULL_BEGIN
     dispatch_once(&onceToken, ^{
         sharedDBConnection = [TSStorageManager sharedManager].newDatabaseConnection;
         sharedDBConnection.objectCacheEnabled = NO;
+#if DEBUG
         sharedDBConnection.permittedTransactions = YDB_AnySyncTransaction;
+#endif
     });
-    
+
     return sharedDBConnection;
 }
 

--- a/src/Storage/TSDatabaseView.h
+++ b/src/Storage/TSDatabaseView.h
@@ -17,19 +17,24 @@ extern NSString *TSMessageDatabaseViewExtensionName;
 extern NSString *TSUnreadDatabaseViewExtensionName;
 extern NSString *TSUnseenDatabaseViewExtensionName;
 extern NSString *TSDynamicMessagesDatabaseViewExtensionName;
+extern NSString *TSSafetyNumberChangeDatabaseViewExtensionName;
 extern NSString *TSSecondaryDevicesDatabaseViewExtensionName;
 
 + (BOOL)registerThreadDatabaseView;
 + (BOOL)registerThreadInteractionsDatabaseView;
+
 // Instances of OWSReadTracking for wasRead is NO and shouldAffectUnreadCounts is YES.
 //
 // Should be used for "unread message counts".
 + (BOOL)registerUnreadDatabaseView;
+
 // Should be used for "unread indicator".
 //
 // Instances of OWSReadTracking for wasRead is NO.
 + (BOOL)registerUnseenDatabaseView;
+
 + (BOOL)registerDynamicMessagesDatabaseView;
++ (BOOL)registerSafetyNumberChangeDatabaseView;
 + (void)asyncRegisterSecondaryDevicesDatabaseView;
 
 @end

--- a/src/Storage/TSDatabaseView.h
+++ b/src/Storage/TSDatabaseView.h
@@ -1,9 +1,5 @@
 //
-//  TSDatabaseView.h
-//  TextSecureKit
-//
-//  Created by Frederic Jacobs on 17/11/14.
-//  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -19,11 +15,13 @@ extern NSString *TSSecondaryDevicesGroup;
 extern NSString *TSThreadDatabaseViewExtensionName;
 extern NSString *TSMessageDatabaseViewExtensionName;
 extern NSString *TSUnreadDatabaseViewExtensionName;
+extern NSString *TSDynamicMessagesDatabaseViewExtensionName;
 extern NSString *TSSecondaryDevicesDatabaseViewExtensionName;
 
 + (BOOL)registerThreadDatabaseView;
 + (BOOL)registerBuddyConversationDatabaseView;
 + (BOOL)registerUnreadDatabaseView;
++ (BOOL)registerDynamicMessagesDatabaseView;
 + (void)asyncRegisterSecondaryDevicesDatabaseView;
 
 @end

--- a/src/Storage/TSDatabaseView.h
+++ b/src/Storage/TSDatabaseView.h
@@ -15,12 +15,20 @@ extern NSString *TSSecondaryDevicesGroup;
 extern NSString *TSThreadDatabaseViewExtensionName;
 extern NSString *TSMessageDatabaseViewExtensionName;
 extern NSString *TSUnreadDatabaseViewExtensionName;
+extern NSString *TSUnseenDatabaseViewExtensionName;
 extern NSString *TSDynamicMessagesDatabaseViewExtensionName;
 extern NSString *TSSecondaryDevicesDatabaseViewExtensionName;
 
 + (BOOL)registerThreadDatabaseView;
-+ (BOOL)registerBuddyConversationDatabaseView;
++ (BOOL)registerThreadInteractionsDatabaseView;
+// Instances of OWSReadTracking for wasRead is NO and shouldAffectUnreadCounts is YES.
+//
+// Should be used for "unread message counts".
 + (BOOL)registerUnreadDatabaseView;
+// Should be used for "unread indicator".
+//
+// Instances of OWSReadTracking for wasRead is NO.
++ (BOOL)registerUnseenDatabaseView;
 + (BOOL)registerDynamicMessagesDatabaseView;
 + (void)asyncRegisterSecondaryDevicesDatabaseView;
 

--- a/src/Storage/TSDatabaseView.m
+++ b/src/Storage/TSDatabaseView.m
@@ -115,11 +115,7 @@ NSString *TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevicesData
         YapDatabaseReadTransaction *transaction, NSString *collection, NSString *key, id object) {
         if ([object isKindOfClass:[TSInvalidIdentityKeyErrorMessage class]]) {
             TSInteraction *interaction = (TSInteraction *)object;
-            if ([interaction isDynamicInteraction]) {
-                return interaction.uniqueThreadId;
-            }
-        } else {
-            OWSAssert(0);
+            return interaction.uniqueThreadId;
         }
         return nil;
     }];

--- a/src/Storage/TSDatabaseView.m
+++ b/src/Storage/TSDatabaseView.m
@@ -116,13 +116,18 @@ NSString *TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevicesData
         if ([object isKindOfClass:[TSInvalidIdentityKeyErrorMessage class]]) {
             TSInteraction *interaction = (TSInteraction *)object;
             return interaction.uniqueThreadId;
+        } else if ([object isKindOfClass:[TSErrorMessage class]]) {
+            TSErrorMessage *errorMessage = (TSErrorMessage *)object;
+            if (errorMessage.errorType == TSErrorMessageNonBlockingIdentityChange) {
+                return errorMessage.uniqueThreadId;
+            }
         }
         return nil;
     }];
 
     return [self registerMessageDatabaseViewWithName:TSSafetyNumberChangeDatabaseViewExtensionName
                                         viewGrouping:viewGrouping
-                                             version:@"1"];
+                                             version:@"2"];
 }
 
 + (BOOL)registerThreadInteractionsDatabaseView

--- a/src/Storage/TSStorageManager.m
+++ b/src/Storage/TSStorageManager.m
@@ -197,8 +197,9 @@ static NSString *keychainDBPassAccount    = @"TSDatabasePass";
 {
     // Register extensions which are essential for rendering threads synchronously
     [TSDatabaseView registerThreadDatabaseView];
-    [TSDatabaseView registerBuddyConversationDatabaseView];
+    [TSDatabaseView registerThreadInteractionsDatabaseView];
     [TSDatabaseView registerUnreadDatabaseView];
+    [TSDatabaseView registerUnseenDatabaseView];
     [TSDatabaseView registerDynamicMessagesDatabaseView];
     [self.database registerExtension:[TSDatabaseSecondaryIndexes registerTimeStampIndex] withName:@"idx"];
 

--- a/src/Storage/TSStorageManager.m
+++ b/src/Storage/TSStorageManager.m
@@ -199,6 +199,7 @@ static NSString *keychainDBPassAccount    = @"TSDatabasePass";
     [TSDatabaseView registerThreadDatabaseView];
     [TSDatabaseView registerBuddyConversationDatabaseView];
     [TSDatabaseView registerUnreadDatabaseView];
+    [TSDatabaseView registerDynamicMessagesDatabaseView];
     [self.database registerExtension:[TSDatabaseSecondaryIndexes registerTimeStampIndex] withName:@"idx"];
 
     // Register extensions which aren't essential for rendering threads async

--- a/src/Storage/TSStorageManager.m
+++ b/src/Storage/TSStorageManager.m
@@ -201,6 +201,7 @@ static NSString *keychainDBPassAccount    = @"TSDatabasePass";
     [TSDatabaseView registerUnreadDatabaseView];
     [TSDatabaseView registerUnseenDatabaseView];
     [TSDatabaseView registerDynamicMessagesDatabaseView];
+    [TSDatabaseView registerSafetyNumberChangeDatabaseView];
     [self.database registerExtension:[TSDatabaseSecondaryIndexes registerTimeStampIndex] withName:@"idx"];
 
     // Register extensions which aren't essential for rendering threads async

--- a/src/Util/Asserts.h
+++ b/src/Util/Asserts.h
@@ -13,24 +13,40 @@
 #define CONVERT_TO_STRING(X) #X
 #define CONVERT_EXPR_TO_STRING(X) CONVERT_TO_STRING(X)
 
-#define OWSAssert(X) \
-if (!(X)) { \
-NSLog(@"Assertion failed: %s", CONVERT_EXPR_TO_STRING(X)); \
-NSAssert(0, @"Assertion failed: %s", CONVERT_EXPR_TO_STRING(X)); \
-}
+// OWSAssert() and OWSFail() should be used in Obj-C methods.
+// OWSCAssert() and OWSCFail() should be used in free functions.
 
-// OWSAssert() should be used in Obj-C and Swift methods.
-// OWSCAssert() should be used in free functions.
-#define OWSCAssert(X) \
-if (!(X)) { \
-NSLog(@"Assertion failed: %s", CONVERT_EXPR_TO_STRING(X)); \
-NSCAssert(0, @"Assertion failed: %s", CONVERT_EXPR_TO_STRING(X)); \
-}
+#define OWSAssert(X)                                                                                                   \
+    if (!(X)) {                                                                                                        \
+        NSLog(@"%s Assertion failed: %s", __PRETTY_FUNCTION__, CONVERT_EXPR_TO_STRING(X));                             \
+        NSAssert(0, @"Assertion failed: %s", CONVERT_EXPR_TO_STRING(X));                                               \
+    }
+
+#define OWSCAssert(X)                                                                                                  \
+    if (!(X)) {                                                                                                        \
+        NSLog(@"%s Assertion failed: %s", __PRETTY_FUNCTION__, CONVERT_EXPR_TO_STRING(X));                             \
+        NSCAssert(0, @"Assertion failed: %s", CONVERT_EXPR_TO_STRING(X));                                              \
+    }
+
+#define OWSFail(X)                                                                                                     \
+    {                                                                                                                  \
+        NSLog(@"%s %@", __PRETTY_FUNCTION__, X);                                                                       \
+        NSAssert(0, X);                                                                                                \
+    }
+
+#define OWSCFail(X)                                                                                                    \
+    {                                                                                                                  \
+        if (!(X)) {                                                                                                    \
+            NSLog(@"%s %@", __PRETTY_FUNCTION__, X);                                                                   \
+            NSCAssert(0, X);                                                                                           \
+        }
 
 #else
 
 #define OWSAssert(X)
 #define OWSCAssert(X)
+#define OWSFail(X)
+#define OWSCFail(X)
 
 #endif
 


### PR DESCRIPTION
Changes for unseen indicator.

* Add a database view for dynamic interactions.
* DRY up the creation of database views.
* Create separate database views for “unseen” and “unread” messages.
* Add “unseen tracking” to info and error messages.
* Rationalize “timestamp” vs. “receipt timestamp”.
* Ensure microsecond precision for interaction sorting.
* Add OWSFail() macros.

PTAL @michaelkirk 