### PR TITLE
When failing to send to new identity, save it.

### DIFF
--- a/src/Messages/Interactions/TSErrorMessage.h
+++ b/src/Messages/Interactions/TSErrorMessage.h
@@ -12,7 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(int32_t, TSErrorMessageType) {
     TSErrorMessageNoSession,
-    TSErrorMessageWrongTrustedIdentityKey,
+    TSErrorMessageWrongTrustedIdentityKey, // DEPRECATED: We no longer create TSErrorMessageWrongTrustedIdentityKey, but
+                                           // persisted legacy messages could exist indefinitly.
     TSErrorMessageInvalidKeyException,
     TSErrorMessageMissingKeyId, // unused
     TSErrorMessageInvalidMessage,

--- a/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.h
+++ b/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.h
@@ -15,11 +15,6 @@ extern NSString *TSInvalidRecipientKey;
 
 @interface TSInvalidIdentityKeySendingErrorMessage : TSInvalidIdentityKeyErrorMessage
 
-+ (instancetype)untrustedKeyWithOutgoingMessage:(TSOutgoingMessage *)outgoingMessage
-                                       inThread:(TSThread *)thread
-                                   forRecipient:(NSString *)recipientId
-                                   preKeyBundle:(PreKeyBundle *)preKeyBundle;
-
 @property (nonatomic, readonly) NSString *messageId;
 
 @end

--- a/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.m
+++ b/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.m
@@ -43,20 +43,12 @@ NSString *TSInvalidRecipientKey = @"TSInvalidRecipientKey";
     return self;
 }
 
-+ (instancetype)untrustedKeyWithOutgoingMessage:(TSOutgoingMessage *)outgoingMessage
-                                       inThread:(TSThread *)thread
-                                   forRecipient:(NSString *)recipientId
-                                   preKeyBundle:(PreKeyBundle *)preKeyBundle
-{
-    TSInvalidIdentityKeySendingErrorMessage *message = [[self alloc] initWithOutgoingMessage:outgoingMessage
-                                                                                    inThread:thread
-                                                                                forRecipient:recipientId
-                                                                                preKeyBundle:preKeyBundle];
-    return message;
-}
-
 - (void)acceptNewIdentityKey
 {
+    // Shouldn't really get here, since we're no longer creating blocking SN changes.
+    // But there may still be some old unaccepted SN errors in the wild that need to be accepted.
+    OWSFail(@"accepting new identity key is deprecated.");
+
     // Saving a new identity mutates the session store so it must happen on the sessionStoreQueue
     dispatch_async([OWSDispatch sessionStoreQueue], ^{
         [[OWSIdentityManager sharedManager] saveRemoteIdentity:self.newIdentityKey recipientId:self.recipientId];

--- a/src/Messages/OWSIdentityManager.h
+++ b/src/Messages/OWSIdentityManager.h
@@ -13,6 +13,9 @@ extern NSString *const TSStorageManagerTrustedKeysCollection;
 // or their verification state changes.
 extern NSString *const kNSNotificationName_IdentityStateDidChange;
 
+// number of bytes in a signal identity key, excluding the key-type byte.
+extern const NSUInteger kIdentityKeyLength;
+
 @class OWSRecipientIdentity;
 @class OWSSignalServiceProtosSyncMessageVerification;
 

--- a/src/Messages/OWSMessageSender.h
+++ b/src/Messages/OWSMessageSender.h
@@ -86,14 +86,6 @@ NS_SWIFT_NAME(MessageSender)
                             success:(void (^)())successHandler
                             failure:(void (^)(NSError *error))failureHandler;
 
-/**
- * Resend a message to a select recipient in a thread when previous sending failed due to key error.
- * e.g. If a key change prevents one recipient from receiving the message, we don't want to resend to the entire group.
- */
-- (void)resendMessageFromKeyError:(TSInvalidIdentityKeySendingErrorMessage *)errorMessage
-                          success:(void (^)())successHandler
-                          failure:(void (^)(NSError *error))failureHandler;
-
 - (void)handleMessageSentRemotely:(TSOutgoingMessage *)message sentAt:(uint64_t)sentAt;
 
 /**

--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -864,9 +864,14 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             // If it's happening a lot, we should rethink our profile fetching strategy.
             OWSAnalyticsInfo(@"Message send failed due to untrusted key.");
 
-            NSError *error = OWSErrorWithCodeDescription(OWSErrorCodeUntrustedIdentityKey,
-                NSLocalizedString(@"FAILED_SENDING_BECAUSE_UNTRUSTED_IDENTITY_KEY",
-                    @"action sheet header when re-sending message which failed because of untrusted identity keys"));
+            NSString *localizedErrorDescriptionFormat
+                = NSLocalizedString(@"FAILED_SENDING_BECAUSE_UNTRUSTED_IDENTITY_KEY",
+                    @"action sheet header when re-sending message which failed because of untrusted identity keys");
+
+            NSString *localizedErrorDescription =
+                [NSString stringWithFormat:localizedErrorDescriptionFormat,
+                          [self.contactsManager displayNameForPhoneIdentifier:recipient.recipientId]];
+            NSError *error = OWSErrorWithCodeDescription(OWSErrorCodeUntrustedIdentityKey, localizedErrorDescription);
 
             // Key will continue to be unaccepted, so no need to retry. It'll only cause us to hit the Pre-Key request
             // rate limit

--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -1001,8 +1001,12 @@ NS_ASSUME_NONNULL_BEGIN
       } else if ([exception.name isEqualToString:InvalidVersionException]) {
           errorMessage = [TSErrorMessage invalidVersionWithEnvelope:envelope withTransaction:transaction];
       } else if ([exception.name isEqualToString:UntrustedIdentityKeyException]) {
-          errorMessage =
-              [TSInvalidIdentityKeyReceivingErrorMessage untrustedKeyWithEnvelope:envelope withTransaction:transaction];
+          // Should no longer get here, since we now record the new identity for incoming messages.
+          OWSFail(@"%@ Failed to trust identity on incoming message from: %@.%d",
+              self.tag,
+              envelope.source,
+              envelope.sourceDevice);
+          return;
       } else {
           errorMessage = [TSErrorMessage corruptedMessageWithEnvelope:envelope withTransaction:transaction];
       }


### PR DESCRIPTION
Remove creation of "old style" blocking SN alerts

PTAL @charlesmchen 