### PR TITLE
Add a default description for verification state messages.

### DIFF
--- a/src/Messages/Interactions/TSInfoMessage.m
+++ b/src/Messages/Interactions/TSInfoMessage.m
@@ -92,6 +92,9 @@ NSUInteger TSInfoMessageSchemaVersion = 1;
         case TSInfoMessageAddToContactsOffer:
             return NSLocalizedString(@"ADD_TO_CONTACTS_OFFER",
                 @"Message shown in conversation view that offers to add an unknown user to your phone's contacts.");
+        case TSInfoMessageVerificationStateChange:
+            return NSLocalizedString(@"VERIFICATION_STATE_CHANGE_GENERIC",
+                @"Generic message indicating that verification state changed for a given user.");
         default:
             break;
     }


### PR DESCRIPTION
This affects how the messages show up in home view.  I'm not going to bother with specific messages for each possible state.

PTAL @michaelkirk 

![screen shot 2017-06-09 at 11 32 04 am](https://user-images.githubusercontent.com/625803/26982724-4a330b6c-4d07-11e7-8358-533cae113723.png)
