### PR TITLE
Charlesmchen/group creation errors

### DIFF
--- a/src/Messages/Interactions/TSErrorMessage.h
+++ b/src/Messages/Interactions/TSErrorMessage.h
@@ -21,6 +21,7 @@ typedef NS_ENUM(int32_t, TSErrorMessageType) {
     TSErrorMessageInvalidVersion,
     TSErrorMessageNonBlockingIdentityChange,
     TSErrorMessageUnknownContactBlockOffer,
+    TSErrorMessageGroupCreationFailed,
 };
 
 - (instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;

--- a/src/Messages/Interactions/TSErrorMessage.m
+++ b/src/Messages/Interactions/TSErrorMessage.m
@@ -115,6 +115,9 @@ NSUInteger TSErrorMessageSchemaVersion = 1;
         case TSErrorMessageUnknownContactBlockOffer:
             return NSLocalizedString(@"UNKNOWN_CONTACT_BLOCK_OFFER",
                 @"Message shown in conversation view that offers to block an unknown user.");
+        case TSErrorMessageGroupCreationFailed:
+            return NSLocalizedString(@"GROUP_CREATION_FAILED",
+                @"Message shown in conversation view that indicates there were issues with group creation.");
         default:
             return NSLocalizedString(@"ERROR_MESSAGE_UNKNOWN_ERROR", @"");
             break;


### PR DESCRIPTION
* We want to avoid users accidentally creating multiple copies of a group due to partial failures during group creation.  If an error occurs, we navigate the user to the newly created group and show a new "group creation failed" interaction. If tapped, it sends a "group update" in an attempt to fix the group. If any member of the group sends a message, the situation should also be rectified when the "missing" members request a "group update".
* Ensure message sends only succeed or fail once.  We had a bug where fatal errors caused the failure handlers to be called twice.  I've fixed this and added asserts to ensure a problem of this form never re-emerges.

PTAL @michaelkirk 