### PR TITLE
Remove an unnecessary database view.

### DIFF
--- a/src/Storage/TSDatabaseView.h
+++ b/src/Storage/TSDatabaseView.h
@@ -14,7 +14,6 @@ extern NSString *TSSecondaryDevicesGroup;
 
 extern NSString *TSThreadDatabaseViewExtensionName;
 extern NSString *TSMessageDatabaseViewExtensionName;
-extern NSString *TSThreadInboxMessagesDatabaseViewExtensionName;
 extern NSString *TSThreadIncomingMessageDatabaseViewExtensionName;
 extern NSString *TSThreadOutgoingMessageDatabaseViewExtensionName;
 extern NSString *TSUnreadDatabaseViewExtensionName;
@@ -25,7 +24,6 @@ extern NSString *TSSecondaryDevicesDatabaseViewExtensionName;
 
 + (BOOL)registerThreadDatabaseView;
 + (BOOL)registerThreadInteractionsDatabaseView;
-+ (BOOL)registerThreadInboxMessageDatabaseView;
 + (BOOL)registerThreadIncomingMessagesDatabaseView;
 + (BOOL)registerThreadOutgoingMessagesDatabaseView;
 

--- a/src/Storage/TSDatabaseView.m
+++ b/src/Storage/TSDatabaseView.m
@@ -20,7 +20,6 @@ NSString *TSSecondaryDevicesGroup = @"TSSecondaryDevicesGroup";
 
 NSString *TSThreadDatabaseViewExtensionName  = @"TSThreadDatabaseViewExtensionName";
 NSString *TSMessageDatabaseViewExtensionName = @"TSMessageDatabaseViewExtensionName";
-NSString *TSThreadInboxMessagesDatabaseViewExtensionName = @"TSThreadInboxMessagesDatabaseViewExtensionName";
 NSString *TSThreadIncomingMessageDatabaseViewExtensionName = @"TSThreadOutgoingMessageDatabaseViewExtensionName";
 NSString *TSThreadOutgoingMessageDatabaseViewExtensionName = @"TSThreadOutgoingMessageDatabaseViewExtensionName";
 NSString *TSUnreadDatabaseViewExtensionName  = @"TSUnreadDatabaseViewExtensionName";
@@ -144,27 +143,6 @@ NSString *TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevicesData
     }];
 
     return [self registerMessageDatabaseViewWithName:TSMessageDatabaseViewExtensionName
-                                        viewGrouping:viewGrouping
-                                             version:@"1"];
-}
-
-+ (BOOL)registerThreadInboxMessageDatabaseView
-{
-    YapDatabaseViewGrouping *viewGrouping = [YapDatabaseViewGrouping withObjectBlock:^NSString *(
-        YapDatabaseReadTransaction *transaction, NSString *collection, NSString *key, id object) {
-        if ([object isKindOfClass:[TSInteraction class]]) {
-            TSInteraction *interaction = (TSInteraction *)object;
-            if (![TSThread shouldInteractionAppearInInbox:interaction]) {
-                return nil;
-            }
-            return interaction.uniqueThreadId;
-        } else {
-            OWSAssert(0);
-        }
-        return nil;
-    }];
-
-    return [self registerMessageDatabaseViewWithName:TSThreadInboxMessagesDatabaseViewExtensionName
                                         viewGrouping:viewGrouping
                                              version:@"1"];
 }

--- a/src/Storage/TSStorageManager.m
+++ b/src/Storage/TSStorageManager.m
@@ -193,10 +193,9 @@ static NSString *keychainDBPassAccount    = @"TSDatabasePass";
 
 - (void)setupDatabase
 {
-    // Register extensions which are essential for rendering threads synchronously
+    // Synchronously register extensions which are essential for views.
     [TSDatabaseView registerThreadDatabaseView];
     [TSDatabaseView registerThreadInteractionsDatabaseView];
-    [TSDatabaseView registerThreadInboxMessageDatabaseView];
     [TSDatabaseView registerThreadIncomingMessagesDatabaseView];
     [TSDatabaseView registerThreadOutgoingMessagesDatabaseView];
     [TSDatabaseView registerUnreadDatabaseView];


### PR DESCRIPTION
We want to remove unnecessary database views for startup perf.  `TSThreadInboxMessagesDatabaseViewExtensionName` only needs to exist for rare edge cases.  We can just reverse-enumerate with `TSMessageDatabaseViewExtensionName` since 99.9% of the time it will stop after the first object in the collection and it will never have to iterate far.

PTAL @michaelkirk 