### PR TITLE
Reduce number of database views.

### DIFF
--- a/src/Storage/TSDatabaseView.h
+++ b/src/Storage/TSDatabaseView.h
@@ -14,17 +14,14 @@ extern NSString *TSSecondaryDevicesGroup;
 
 extern NSString *TSThreadDatabaseViewExtensionName;
 extern NSString *TSMessageDatabaseViewExtensionName;
-extern NSString *TSThreadIncomingMessageDatabaseViewExtensionName;
 extern NSString *TSThreadOutgoingMessageDatabaseViewExtensionName;
 extern NSString *TSUnreadDatabaseViewExtensionName;
 extern NSString *TSUnseenDatabaseViewExtensionName;
-extern NSString *TSDynamicMessagesDatabaseViewExtensionName;
-extern NSString *TSSafetyNumberChangeDatabaseViewExtensionName;
+extern NSString *TSThreadSpecialMessagesDatabaseViewExtensionName;
 extern NSString *TSSecondaryDevicesDatabaseViewExtensionName;
 
 + (BOOL)registerThreadDatabaseView;
 + (BOOL)registerThreadInteractionsDatabaseView;
-+ (BOOL)registerThreadIncomingMessagesDatabaseView;
 + (BOOL)registerThreadOutgoingMessagesDatabaseView;
 
 // Instances of OWSReadTracking for wasRead is NO and shouldAffectUnreadCounts is YES.
@@ -37,8 +34,7 @@ extern NSString *TSSecondaryDevicesDatabaseViewExtensionName;
 // Instances of OWSReadTracking for wasRead is NO.
 + (BOOL)registerUnseenDatabaseView;
 
-+ (BOOL)registerDynamicMessagesDatabaseView;
-+ (BOOL)registerSafetyNumberChangeDatabaseView;
++ (BOOL)registerThreadSpecialMessagesDatabaseView;
 + (void)asyncRegisterSecondaryDevicesDatabaseView;
 
 @end

--- a/src/Storage/TSDatabaseView.m
+++ b/src/Storage/TSDatabaseView.m
@@ -20,12 +20,10 @@ NSString *TSSecondaryDevicesGroup = @"TSSecondaryDevicesGroup";
 
 NSString *TSThreadDatabaseViewExtensionName  = @"TSThreadDatabaseViewExtensionName";
 NSString *TSMessageDatabaseViewExtensionName = @"TSMessageDatabaseViewExtensionName";
-NSString *TSThreadIncomingMessageDatabaseViewExtensionName = @"TSThreadOutgoingMessageDatabaseViewExtensionName";
 NSString *TSThreadOutgoingMessageDatabaseViewExtensionName = @"TSThreadOutgoingMessageDatabaseViewExtensionName";
 NSString *TSUnreadDatabaseViewExtensionName  = @"TSUnreadDatabaseViewExtensionName";
 NSString *TSUnseenDatabaseViewExtensionName = @"TSUnseenDatabaseViewExtensionName";
-NSString *TSDynamicMessagesDatabaseViewExtensionName = @"TSDynamicMessagesDatabaseViewExtensionName";
-NSString *TSSafetyNumberChangeDatabaseViewExtensionName = @"TSSafetyNumberChangeDatabaseViewExtensionName";
+NSString *TSThreadSpecialMessagesDatabaseViewExtensionName = @"TSThreadSpecialMessagesDatabaseViewExtensionName";
 NSString *TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevicesDatabaseViewExtensionName";
 
 @implementation TSDatabaseView
@@ -91,31 +89,16 @@ NSString *TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevicesData
                                              version:@"1"];
 }
 
-+ (BOOL)registerDynamicMessagesDatabaseView
++ (BOOL)registerThreadSpecialMessagesDatabaseView
 {
     YapDatabaseViewGrouping *viewGrouping = [YapDatabaseViewGrouping withObjectBlock:^NSString *(
         YapDatabaseReadTransaction *transaction, NSString *collection, NSString *key, id object) {
-        if ([object isKindOfClass:[TSInteraction class]]) {
-            TSInteraction *interaction = (TSInteraction *)object;
-            if ([interaction isDynamicInteraction]) {
-                return interaction.uniqueThreadId;
-            }
-        } else {
-            OWSAssert(0);
-        }
-        return nil;
-    }];
+        OWSAssert([object isKindOfClass:[TSInteraction class]]);
 
-    return [self registerMessageDatabaseViewWithName:TSDynamicMessagesDatabaseViewExtensionName
-                                        viewGrouping:viewGrouping
-                                             version:@"3"];
-}
-
-+ (BOOL)registerSafetyNumberChangeDatabaseView
-{
-    YapDatabaseViewGrouping *viewGrouping = [YapDatabaseViewGrouping withObjectBlock:^NSString *(
-        YapDatabaseReadTransaction *transaction, NSString *collection, NSString *key, id object) {
-        if ([object isKindOfClass:[TSInvalidIdentityKeyErrorMessage class]]) {
+        TSInteraction *interaction = (TSInteraction *)object;
+        if ([interaction isDynamicInteraction]) {
+            return interaction.uniqueThreadId;
+        } else if ([object isKindOfClass:[TSInvalidIdentityKeyErrorMessage class]]) {
             TSInteraction *interaction = (TSInteraction *)object;
             return interaction.uniqueThreadId;
         } else if ([object isKindOfClass:[TSErrorMessage class]]) {
@@ -127,37 +110,22 @@ NSString *TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevicesData
         return nil;
     }];
 
-    return [self registerMessageDatabaseViewWithName:TSSafetyNumberChangeDatabaseViewExtensionName
+    return [self registerMessageDatabaseViewWithName:TSThreadSpecialMessagesDatabaseViewExtensionName
                                         viewGrouping:viewGrouping
-                                             version:@"2"];
+                                             version:@"1"];
 }
 
 + (BOOL)registerThreadInteractionsDatabaseView
 {
     YapDatabaseViewGrouping *viewGrouping = [YapDatabaseViewGrouping withObjectBlock:^NSString *(
         YapDatabaseReadTransaction *transaction, NSString *collection, NSString *key, id object) {
-        if ([object isKindOfClass:[TSInteraction class]]) {
-            return ((TSInteraction *)object).uniqueThreadId;
-        }
-        return nil;
+        OWSAssert([object isKindOfClass:[TSInteraction class]]);
+
+        TSInteraction *interaction = (TSInteraction *)object;
+        return interaction.uniqueThreadId;
     }];
 
     return [self registerMessageDatabaseViewWithName:TSMessageDatabaseViewExtensionName
-                                        viewGrouping:viewGrouping
-                                             version:@"1"];
-}
-
-+ (BOOL)registerThreadIncomingMessagesDatabaseView
-{
-    YapDatabaseViewGrouping *viewGrouping = [YapDatabaseViewGrouping withObjectBlock:^NSString *(
-        YapDatabaseReadTransaction *transaction, NSString *collection, NSString *key, id object) {
-        if ([object isKindOfClass:[TSIncomingMessage class]]) {
-            return ((TSIncomingMessage *)object).uniqueThreadId;
-        }
-        return nil;
-    }];
-
-    return [self registerMessageDatabaseViewWithName:TSThreadIncomingMessageDatabaseViewExtensionName
                                         viewGrouping:viewGrouping
                                              version:@"1"];
 }
@@ -174,7 +142,7 @@ NSString *TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevicesData
 
     return [self registerMessageDatabaseViewWithName:TSThreadOutgoingMessageDatabaseViewExtensionName
                                         viewGrouping:viewGrouping
-                                             version:@"1"];
+                                             version:@"2"];
 }
 
 + (BOOL)registerThreadDatabaseView {

--- a/src/Storage/TSStorageManager.m
+++ b/src/Storage/TSStorageManager.m
@@ -196,12 +196,10 @@ static NSString *keychainDBPassAccount    = @"TSDatabasePass";
     // Synchronously register extensions which are essential for views.
     [TSDatabaseView registerThreadDatabaseView];
     [TSDatabaseView registerThreadInteractionsDatabaseView];
-    [TSDatabaseView registerThreadIncomingMessagesDatabaseView];
     [TSDatabaseView registerThreadOutgoingMessagesDatabaseView];
     [TSDatabaseView registerUnreadDatabaseView];
     [TSDatabaseView registerUnseenDatabaseView];
-    [TSDatabaseView registerDynamicMessagesDatabaseView];
-    [TSDatabaseView registerSafetyNumberChangeDatabaseView];
+    [TSDatabaseView registerThreadSpecialMessagesDatabaseView];
     [self.database registerExtension:[TSDatabaseSecondaryIndexes registerTimeStampIndex] withName:@"idx"];
 
     // Register extensions which aren't essential for rendering threads async


### PR DESCRIPTION
First startup times are still slow for users with large numbers of messages, but these changes help (for a user with ~13,000 messages across 4 threads, startup times that were ~80 seconds are now ~50 seconds).  

PTAL @michaelkirk 