### PR TITLE
append/remove key type as necessary to fix verification syncing

### DIFF
--- a/src/Devices/OWSVerificationStateSyncMessage.m
+++ b/src/Devices/OWSVerificationStateSyncMessage.m
@@ -4,6 +4,7 @@
 
 #import "OWSVerificationStateSyncMessage.h"
 #import "Cryptography.h"
+#import "OWSIdentityManager.h"
 #import "OWSSignalServiceProtos.pb.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -50,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
                  identityKey:(NSData *)identityKey
                  recipientId:(NSString *)recipientId
 {
-    OWSAssert(identityKey.length > 0);
+    OWSAssert(identityKey.length == kIdentityKeyLength);
     OWSAssert(recipientId.length > 0);
     OWSAssert(self.tuples);
 

--- a/src/Messages/OWSMessageSender.m
+++ b/src/Messages/OWSMessageSender.m
@@ -909,18 +909,21 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             }
 
             NSData *newIdentityKeyWithVersion = newKeyBundle.identityKey;
+
             if (![newIdentityKeyWithVersion isKindOfClass:[NSData class]]) {
                 OWSFail(@"%@ unexpected TSInvalidRecipientKey: %@", self.tag, newIdentityKeyWithVersion);
                 failureHandler(error);
                 return;
             }
 
-            NSData *newIdentityKey = [newIdentityKeyWithVersion removeKeyType];
-            if (newIdentityKey.length != kIdentityKeyLength) {
-                OWSFail(@"%@ unexpected key length: %lu", self.tag, (unsigned long)newIdentityKey.length);
+            // TODO migrate to storing the full 33 byte representation of the identity key.
+            if (newIdentityKeyWithVersion.length != kIdentityKeyLength) {
+                OWSFail(@"%@ unexpected key length: %lu", self.tag, (unsigned long)newIdentityKeyWithVersion.length);
                 failureHandler(error);
                 return;
             }
+
+            NSData *newIdentityKey = [newIdentityKeyWithVersion removeKeyType];
 
             [[OWSIdentityManager sharedManager] saveRemoteIdentity:newIdentityKey recipientId:recipient.recipientId];
 


### PR DESCRIPTION
PTAL @charlesmchen 

Note that I had to locally toggle the sync feature-flag to test this.

It's kind of hairy, but I was trying to move as little code as possible before the release.

Longer term we should migrate the db to simplify the code paths.