### PR TITLE
Add creation timestamp to attachment streams.

### DIFF
--- a/src/Messages/Attachments/TSAttachmentStream.h
+++ b/src/Messages/Attachments/TSAttachmentStream.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 // This only applies for attachments being uploaded.
 @property (atomic) BOOL isUploaded;
 
+@property (nonatomic, readonly) NSDate *creationTimestamp;
+
 #if TARGET_OS_IPHONE
 - (nullable UIImage *)image;
 #endif

--- a/src/Messages/Attachments/TSAttachmentStream.m
+++ b/src/Messages/Attachments/TSAttachmentStream.m
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
     // state, but this constructor is used only for new outgoing
     // attachments which haven't been uploaded yet.
     _isUploaded = NO;
+    _creationTimestamp = [NSDate new];
 
     [self ensureFilePath];
 
@@ -62,6 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
     // attachments which don't need to be uploaded.
     _isUploaded = YES;
     self.attachmentType = pointer.attachmentType;
+    _creationTimestamp = [NSDate new];
 
     [self ensureFilePath];
 
@@ -75,7 +77,13 @@ NS_ASSUME_NONNULL_BEGIN
         return self;
     }
 
+    // OWS105AttachmentFilePaths will ensure the file path is saved if necessary.
     [self ensureFilePath];
+
+    // OWS105AttachmentFilePaths will ensure the creation timestamp is saved if necessary.
+    if (!_creationTimestamp) {
+        _creationTimestamp = [NSDate new];
+    }
 
     return self;
 }


### PR DESCRIPTION
We're going to use this in the future when cleaning up orphan timestamps.  It's important to get it into v2.13.0.0 so that we can piggyback on the "save all TSAttachmentStream instances" migration.

PTAL @michaelkirk 