### PR TITLE
Archive sessions upon identity change.

### DIFF
--- a/src/Messages/OWSIdentityManager.m
+++ b/src/Messages/OWSIdentityManager.m
@@ -6,8 +6,8 @@
 #import "NSDate+millisecondTimeStamp.h"
 #import "NotificationsProtocol.h"
 #import "OWSMessageSender.h"
-#import "OWSRecipientIdentity.h"
 #import "OWSOutgoingNullMessage.h"
+#import "OWSRecipientIdentity.h"
 #import "OWSVerificationStateChangeMessage.h"
 #import "OWSVerificationStateSyncMessage.h"
 #import "TSAccountManager.h"
@@ -15,6 +15,7 @@
 #import "TSErrorMessage.h"
 #import "TSGroupThread.h"
 #import "TSStorageManager+keyingMaterial.h"
+#import "TSStorageManager+sessionStore.h"
 #import "TSStorageManager.h"
 #import "TextSecureKitEnv.h"
 #import <25519/Curve25519.h>
@@ -196,6 +197,8 @@ NSString *const kNSNotificationName_IdentityStateDidChange = @"kNSNotificationNa
                                                isFirstKnownKey:NO
                                                      createdAt:[NSDate new]
                                              verificationState:verificationState] save];
+
+            [self.storageManager archiveAllSessionsForContact:recipientId];
 
             // Cancel any pending verification state sync messages for this recipient.
             [self clearSyncMessageForRecipientId:recipientId];

--- a/src/Storage/AxolotlStore/TSStorageManager+SessionStore.m
+++ b/src/Storage/AxolotlStore/TSStorageManager+SessionStore.m
@@ -170,7 +170,6 @@ void AssertIsOnSessionStoreQueue()
         sessionRecords =
             [transaction objectForKey:contactIdentifier inCollection:TSStorageManagerSessionStoreCollection];
 
-
         for (id deviceId in sessionRecords) {
             id object = sessionRecords[deviceId];
             if (![object isKindOfClass:[SessionRecord class]]) {


### PR DESCRIPTION
Session clearing must be in IdentityKeyStore implementation

Trying to do it in the protocol will not work with multiple devices,
because we'll only archive the session of the first sending device.

See also: https://github.com/WhisperSystems/SignalProtocolKit/pull/29

PTAL @charlesmchen 