### PR TITLE
updates badge count when app is backgrounded

### DIFF
--- a/src/Messages/TSMessagesManager.m
+++ b/src/Messages/TSMessagesManager.m
@@ -115,7 +115,22 @@ NS_ASSUME_NONNULL_BEGIN
 
     OWSSingletonAssert();
 
+    [self startObserving];
+
     return self;
+}
+
+- (void)startObserving
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(yapDatabaseModified:)
+                                                 name:YapDatabaseModifiedNotification
+                                               object:nil];
+}
+
+- (void)yapDatabaseModified:(NSNotification *)notification
+{
+    [self updateApplicationBadgeCount];
 }
 
 #pragma mark - Debugging
@@ -1066,6 +1081,12 @@ NS_ASSUME_NONNULL_BEGIN
     }];
 
     return numberOfItems;
+}
+
+- (void)updateApplicationBadgeCount
+{
+    NSUInteger numberOfItems = [self unreadMessagesCount];
+    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:numberOfItems];
 }
 
 - (NSUInteger)unreadMessagesInThread:(TSThread *)thread {


### PR DESCRIPTION
Previously we were updating badge count as a side effect of SingalsViewController's yapDatabaseModified, but because we do lots of rendering work in that method, we opted to stop observing when the view wasn't visible.

I initially considered not doing this with notifications, and instead trying to be more explicit with updateBadgeCount calls in all the places that would create/remove unread count, but I opted for the safer option, after realizing there were multiple places this could happen.

e.g. at least these places would have to be instrumented:

- receiving a message
- marking message as read
- deleting a thread
- in practice it *shouldn't* be possible to delete an individual unread message, but it seems like it could be a future edge case, so I'd want to do it there too.

I wasn't convinced I thought of every place, so I went for the safer approach - having message manager observe db modifications - just like SVC did prior to 2.13, so we get the correctness, but at least now we're not shuffling table cells or other things, so it should be faster than 2.12.


see also: https://github.com/WhisperSystems/Signal-iOS/pull/2277

PTAL @charlesmchen 
