### PR TITLE
FIX: verifiying unregistered user prints "no longer registered" error on

### DIFF
--- a/src/Messages/OWSIdentityManager.m
+++ b/src/Messages/OWSIdentityManager.m
@@ -5,6 +5,7 @@
 #import "OWSIdentityManager.h"
 #import "NSDate+millisecondTimeStamp.h"
 #import "NotificationsProtocol.h"
+#import "OWSError.h"
 #import "OWSMessageSender.h"
 #import "OWSOutgoingNullMessage.h"
 #import "OWSRecipientIdentity.h"
@@ -537,6 +538,13 @@ NSString *const kNSNotificationName_IdentityStateDidChange = @"kNSNotificationNa
         }
         failure:^(NSError *_Nonnull error) {
             DDLogError(@"%@ Failed to send verification state NullMessage with error: %@", self.tag, error);
+            if (error.code == OWSErrorCodeNoSuchSignalRecipient) {
+                DDLogInfo(@"%@ Removing retries for syncing verification state, since user is no longer registered: %@",
+                    self.tag,
+                    message.verificationForRecipientId);
+                // Otherwise this will fail forever.
+                [self clearSyncMessageForRecipientId:message.verificationForRecipientId];
+            }
         }];
 }
 


### PR DESCRIPTION
every launch

This happens if you ever try to mark an unregistered user as (un)/verified.

PTAL @charlesmchen 