### PR TITLE
Persist thread view

### DIFF
--- a/src/Storage/TSDatabaseView.m
+++ b/src/Storage/TSDatabaseView.m
@@ -231,7 +231,7 @@ NSString *const TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevic
     YapDatabaseViewSorting *viewSorting = [self threadSorting];
 
     YapDatabaseViewOptions *options = [[YapDatabaseViewOptions alloc] init];
-    options.isPersistent            = NO;
+    options.isPersistent = YES;
     options.allowedCollections =
         [[YapWhitelistBlacklist alloc] initWithWhitelist:[NSSet setWithObject:[TSThread collection]]];
 


### PR DESCRIPTION
Not for the hotfix, since we've been living with this for a while, but it should give a little boost to startup after the initial persistence. It *will* run blocking sync, but it should be a pretty small set (n = thread count).

We'll want to be careful with testing this one... doing some git archeology it comes from this commit in Signal-iOS:

```
commit dfdd0a197418fe9bef6128eebaad06aa63a87c6b
Author: Frederic Jacobs <github@fredericjacobs.com>
Date:   Mon Feb 16 10:27:08 2015 +0100

    Support for `remoteRegistrationId`.

    1) Supporting `remoteRegistrationId` on sending messages. Now showing
    warning before sending the message if key conflict exists. Fixes #574
    2) Upgrading dependencies: adapting to new libPhoneNumber API.
    3) Fixes race condition in database code.
    4) Fixing ordering bug. Hopefully once and for good.
```

My guess is that it was related to 3 or 4. I could imagine the ordering being incorrect if the thread wasn't always being touched properly after interactions in the thread were added/destroyed, but I believe we're doing that now.

PTAL @charlesmchen 